### PR TITLE
preserve module this in IndexedDB onsuccess handler

### DIFF
--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -328,7 +328,7 @@ class PassiveDataKitModule extends WebmunkServiceWorkerModule {
 
         const request = index.getAll(0, 64)
 
-        request.onsuccess = function () {
+        request.onsuccess = () => {
           const pendingItems = request.result
 
           if (pendingItems.length === 0) {


### PR DESCRIPTION
With () => {}, this is lexically captured from the surrounding method (PassiveDataKitModule instance), so all the this.* calls in that handler correctly refer to the module.