### PR TITLE
Fix race condition and missing return in uploadQueuedDataPoints

### DIFF
--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -288,6 +288,12 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
     return new Promise<void>((resolve, reject) => {
       if (this.currentlyUploading) {
         resolve()
+        return
+      }
+
+      if (this.database === null) {
+        resolve()
+        return
       }
 
       const index = this.database.transaction(['dataPoints'], 'readonly')


### PR DESCRIPTION
- Add null guard for this.database to handle the case where uploadQueuedDataPoints is called before IndexedDB onsuccess fires
- Add missing return after resolve() when currentlyUploading is true to prevent concurrent uploads bypassing the guard

## Problem

  Two bugs in `uploadQueuedDataPoints` caused errors on service worker startup:

  **Bug 1 — Missing `return` after `resolve()` (concurrency guard broken)**

  When `currentlyUploading` is `true`, the method called `resolve()` but continued
  executing, bypassing the guard entirely. This allowed concurrent uploads to run
  simultaneously, risking duplicate data points being sent to the server.

  **Bug 2 — Race condition: `this.database` is `null` on first call**

  `setup()` opens IndexedDB asynchronously and sets `this.database` in `onsuccess`,
  but immediately calls `refreshConfiguration()` synchronously. If the configuration
  is already cached, `refreshConfiguration()` resolves quickly and calls
  `uploadQueuedDataPoints()` before `onsuccess` fires — crashing with:

    TypeError: Cannot read properties of null (reading 'transaction')

  This caused any queued data points from prior sessions to silently fail to upload
  on startup.

  ## Fix

  - Added `return` after `resolve()` when `currentlyUploading` is true
  - Added a `null` guard on `this.database` that resolves cleanly if called before
    the database is ready

  ## Testing

  Verified in Keystone-Chrome-Extension: the `TypeError` no longer appears in the
  service worker on startup.

---

<!-- continue-task-summary-start -->
**Continue Tasks:** ▶️ 1 queued — [View all](https://hub.continue.dev/inbox/pr/bric-digital/rex-passive-data-kit/22?utm_source=github_pr&utm_medium=pr_body&utm_campaign=continue_tasks)
<!-- continue-task-summary-end -->