### PR TITLE
await idb writes and recursion in updateDataPoints to prevent re-upload race

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -755,6 +755,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
             "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.59.1",
                 "@typescript-eslint/types": "8.59.1",
@@ -950,6 +951,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
             "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1394,6 +1396,7 @@
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
             "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.2",
@@ -1951,6 +1954,7 @@
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -2339,6 +2343,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -2799,6 +2804,7 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
             "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -385,27 +385,29 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
     return new Promise<void>((resolve, reject) => {
       if (dataPoints.length === 0 || this.database === null) {
         resolve()
-      } else {
-        const dataPoint: REXPDKDataPointDBRecord | undefined = dataPoints.pop()
+        return
+      }
 
-        if (dataPoint !== undefined) {
-          const request = this.database.transaction(['dataPoints'], 'readwrite')
-            .objectStore('dataPoints')
-            .put(dataPoint)
+      const dataPoint: REXPDKDataPointDBRecord | undefined = dataPoints.pop()
 
-          request.onsuccess = (event) => { // eslint-disable-line @typescript-eslint/no-unused-vars
-            this.updateDataPoints(dataPoints)
-          }
-
-          request.onerror = (error) => {
-            console.log('[rex-passive-data-kit] The data update has has failed.')
-            console.log(error)
-
-            reject(error)
-          }
-        }
-
+      if (dataPoint === undefined) {
         resolve()
+        return
+      }
+
+      const request = this.database.transaction(['dataPoints'], 'readwrite')
+        .objectStore('dataPoints')
+        .put(dataPoint)
+
+      request.onsuccess = (event) => { // eslint-disable-line @typescript-eslint/no-unused-vars
+        this.updateDataPoints(dataPoints).then(resolve, reject)
+      }
+
+      request.onerror = (error) => {
+        console.log('[rex-passive-data-kit] The data update has has failed.')
+        console.log(error)
+
+        reject(error)
       }
     })
   }


### PR DESCRIPTION
This happens to be a PR, but it would be a bug report if I didn't need to get a release to Keystone now. The issue is that the history records are coming up as duplicated, and this looks like the likely cause. It fixes the test, not sure if it is the right fix for the problem itself.