### PR TITLE
guard synchronous point transmission against unset identifier

### DIFF
--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -661,6 +661,18 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
         this.identifier = event['source']
       }
 
+      if (this.identifier === undefined || this.identifier === null) {
+        console.warn('[rex-passive-data-kit] Identifier not set. Skipping synchronous point transmission.')
+
+        resolve({
+          logged: false,
+          url: pointUrl,
+          status: 'Identifier not set. Skipping'
+        })
+
+        return
+      }
+
       const pointPayload:REXPDKDataPoint = {
         'passive-data-metadata': {
           source: `${this.identifier}`,

--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -661,7 +661,7 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
         this.identifier = event['source']
       }
 
-      if (this.identifier === undefined || this.identifier === null) {
+      if (this.identifier === undefined || this.identifier === null || this.identifier === '') {
         console.warn('[rex-passive-data-kit] Identifier not set. Skipping synchronous point transmission.')
 
         resolve({


### PR DESCRIPTION
Follow-up to the fix you made in the standup today (f549882) - that fix only guards the batched upload path, but not the synchronous single-point path, and this PR adds a matching guard. 

Take it or leave it — small symmetry fix on top of your change.