### PR TITLE
serialize concurrent uploads by actually setting the currentlyUploadiing guard

### DIFF
--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -455,16 +455,29 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
   }
 
   async uploadQueuedDataPoints(progressCallback: any, responses:any[] = []) { // eslint-disable-line @typescript-eslint/no-explicit-any
+    // Serialize uploads: overlapping calls (a scheduled upload plus a
+    // config-apply notification, for instance) would read the same
+    // untransmitted points and transmit them twice. The flag must be set
+    // synchronously, before any await, or two same-tick calls both pass the
+    // check. In-memory on purpose: a killed worker restarts with it clear.
+    if (this.currentlyUploading) {
+      return Promise.reject('Still uploading data points. Skipping...')
+    }
+
+    this.currentlyUploading = true
+
     // Points enqueued inside the persist throttle window are still in memory;
     // persist them first so the IndexedDB read below sees everything enqueued so far.
     await this.persistDataPoints()
 
     return new Promise<any>((resolveUploadQueued, reject) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-      if (this.currentlyUploading) {
-        reject('Still uploading data points. Skipping...')
-      } else if (this.database === null) {
+      if (this.database === null) {
+        this.currentlyUploading = false
+
         reject('Database not yet open. Skipping')
       } else if (this.identifier === undefined || this.identifier === null) {
+        this.currentlyUploading = false
+
         reject('Identifier not set. Skipping')
       } else {
         const index = this.database.transaction(['dataPoints'], 'readonly')
@@ -657,6 +670,8 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
             console.log('[rex-passive-data-kit] PDK database error. Unable to retrieve pending points.')
             console.log(event)
 
+            this.currentlyUploading = false
+
             reject(`Database error: ${event}`)
           }
         }
@@ -664,6 +679,8 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
         countRequest.onerror = (event) => {
           console.log('[rex-passive-data-kit] PDK database error. Unable to retrieve count of pending points.')
           console.log(event)
+
+          this.currentlyUploading = false
 
           reject(`Database error: ${event}`)
         }

--- a/tests/specs/serviceworker-concurrent-upload.spec.ts
+++ b/tests/specs/serviceworker-concurrent-upload.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from './fixtures';
+
+// Two upload triggers can overlap (e.g. a config-apply notification firing
+// refreshConfiguration while a scheduled upload is in flight). Overlapping
+// uploads read the same untransmitted points and ship them twice, so the
+// upload path must be serialized: a point enqueued once reaches the server
+// exactly once no matter how many triggers fire.
+
+function countPointsByGenerator(results, generatorId) {
+  let count = 0
+  for (const result of results) {
+    if (!Array.isArray(result)) continue
+    for (const response of result) {
+      if (response === null || typeof response !== 'object' || !Array.isArray(response.payload)) continue
+      for (const dataPoint of response.payload) {
+        if (dataPoint.generatorId === generatorId) count++
+      }
+    }
+  }
+  return count
+}
+
+test('concurrent upload calls transmit each point exactly once', async ({serviceWorker}) => {
+  const settled = await serviceWorker.evaluate(async () => {
+    await new Promise((readyDelay) => self.setTimeout(readyDelay, 1000))
+
+    await new Promise((logged) => {
+      self.rexCorePlugin.handleMessage({
+        'messageType': 'logEvent',
+        'event': {
+          'name': 'rex-pdk-concurrent-test'
+        }
+      }, self, logged)
+    })
+
+    await new Promise((settleDelay) => self.setTimeout(settleDelay, 1500))
+
+    const results = await Promise.allSettled([
+      self.rexPDKPlugin.uploadQueuedDataPoints(() => {}),
+      self.rexPDKPlugin.uploadQueuedDataPoints(() => {}),
+    ])
+
+    return results.map((result) => (result.status === 'fulfilled' ? result.value : `rejected: ${result.reason}`))
+  })
+
+  expect(countPointsByGenerator(settled, 'rex-pdk-concurrent-test')).toEqual(1)
+})


### PR DESCRIPTION
This might be the double-uploading issue also found elsewhere.

## Summary

uploadQueuedDataPoints has always had a currentlyUploading guard, but nothing ever
set it to true, so it never guarded anything. Two overlapping upload triggers both
pass the check, read the same untransmitted points from IndexedDB, and transmit
them twice.

This was latent for as long as callers happened to serialize their own triggers.
rex-core #89 (notify modules on config appth, config
apply -> refreshConfiguration -> uploadQueuedDataPoints, that runs concurrently
with scheduled uploads, which made the duplication deterministic: a downstream
extension's acceptance suite failed with exactly doubled page-visit events.
Deployments have been exposed to occasional duplicates from rare trigger overlap
all along.

## The fix

Set the flag synchronously at entry, beforon every exit
path (empty queue, completion, upload errors, DB errors, and the early db/identifier
rejects). Kept in-memory on purpose: a kils with the flag
clear, so a mid-upload suspension cannot wedge future uploads the way a persisted
flag would.

## Validation

- New spec: two same-tick uploadQueuedDataPoints calls, asserts the logged point
  reaches the server exactly once. Fails owith the fix.
- Full suite 5 passed, build and lint clean.
- Verified in the downstream extension's suite: the doubling reproducer spec goes                                 4/4 with rex-core main plus this branch,