### PR TITLE
Feature/v3 bearer put upload

### DIFF
--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -50,6 +50,31 @@ export interface REXPDKConfiguration {
   endpoint: string,
   identifier: string,
   field_key?: string,
+  endpoint_version?: string,
+  authorization?: REXPDKAuthorization,
+  ignored_identifiers?: string[],
+}
+
+export interface REXPDKAuthorization {
+  token?: string,
+}
+
+export class REXPDKUploadError extends Error {
+  status: number
+  responseBody: unknown
+
+  constructor(status: number, responseBody: unknown) {
+    super(`Data bundle upload failed with HTTP ${status}.`)
+
+    this.name = 'REXPDKUploadError'
+    this.status = status
+    this.responseBody = responseBody
+  }
+}
+
+const PDK_UPLOAD_SUCCESS_REPLY = {
+  message: 'Data bundle added successfully, and ready for processing.',
+  added: true,
 }
 
 export interface REXPDKEvent {
@@ -73,6 +98,9 @@ export class PassiveDataKitPointAnnotator {
 
 class PassiveDataKitModule extends REXServiceWorkerModule {
   uploadUrl: string = ''
+  endpointVersion: string = ''
+  bearerToken: string = ''
+  ignoredIdentifiers: string[] = []
   serverKey: string = ''
   serverFieldKey: Uint8Array<ArrayBufferLike> | null = null
   localFieldKey: Uint8Array<ArrayBufferLike> | null = null
@@ -136,7 +164,13 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
 
   updateConfiguration(config: REXPDKConfiguration) {
     this.uploadUrl = config['endpoint']
-    
+
+    // Validation waits until upload time: a configuration refresh that throws
+    // would leave the module wedged on a stale endpoint.
+    this.endpointVersion = config['endpoint_version'] || ''
+    this.bearerToken = config['authorization']?.token || ''
+    this.ignoredIdentifiers = config['ignored_identifiers'] || []
+
     if (config['identifier'] !== undefined && config['identifier'] !== null) {
       this.identifier = config['identifier']
     } else {
@@ -326,101 +360,172 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
     })
   }
 
-  async uploadBundle(points:REXPDKDataPoint[]) {
-    return new Promise<any>((resolve, reject) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-      const manifest = chrome.runtime.getManifest()
+  stampPointMetadata(points:REXPDKDataPoint[]) {
+    const manifest = chrome.runtime.getManifest()
 
-      const keyPair = nacl.box.keyPair() // eslint-disable-line @typescript-eslint/no-unused-vars
+    const keyPair = nacl.box.keyPair() // eslint-disable-line @typescript-eslint/no-unused-vars
 
-      const serverPublicKey = naclUtil.decodeBase64(this.serverKey) // eslint-disable-line @typescript-eslint/no-unused-vars
+    const serverPublicKey = naclUtil.decodeBase64(this.serverKey) // eslint-disable-line @typescript-eslint/no-unused-vars
 
-      const userAgent = manifest.name + '/' + manifest.version + ' ' + navigator.userAgent
+    const userAgent = manifest.name + '/' + manifest.version + ' ' + navigator.userAgent
 
-      for (let i = 0; i < points.length; i++) {
-        let pointDate:number|undefined = points[i].date
+    for (let i = 0; i < points.length; i++) {
+      let pointDate:number|undefined = points[i].date
 
-        if (pointDate === undefined) {
-          pointDate = Date.now()
-        }
-
-        const metadata: REXPDKPointMetadata = {
-          source: `${this.identifier}`,
-          generator: points[i].generatorId + ': ' + userAgent,
-          'generator-id': points[i].generatorId,
-          timestamp: pointDate / 1000,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        }
-
-        if (points[i].configurationHash !== undefined) {
-          metadata['configuration-hash'] = points[i].configurationHash
-
-          delete points[i].configurationHash
-        }
-
-        if (points[i].enqueuedAt !== undefined) {
-          metadata['enqueued-at'] = points[i].enqueuedAt
-
-          delete points[i].enqueuedAt
-        }
-
-        if (points[i].date === undefined) {
-          points[i].date = (new Date()).getTime()
-        }
-
-        // metadata['generated-key'] = nacl.util.encodeBase64(keyPair.publicKey)
-
-        points[i]['passive-data-metadata'] = metadata
-
-        // pdk.encryptFields(serverPublicKey, keyPair.secretKey, points[i])
+      if (pointDate === undefined) {
+        pointDate = Date.now()
       }
 
-      const dataString = JSON.stringify(points, null, 2)
+      const metadata: REXPDKPointMetadata = {
+        source: `${this.identifier}`,
+        generator: points[i].generatorId + ': ' + userAgent,
+        'generator-id': points[i].generatorId,
+        timestamp: pointDate / 1000,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }
 
-      const byteArray = new TextEncoder().encode(dataString)
-      const cs = new CompressionStream('gzip')
-      const writer = cs.writable.getWriter()
-      writer.write(byteArray)
-      writer.close()
+      if (points[i].configurationHash !== undefined) {
+        metadata['configuration-hash'] = points[i].configurationHash
 
-      const compressedResponse = new Response(cs.readable)
+        delete points[i].configurationHash
+      }
 
-      compressedResponse.arrayBuffer()
-        .then((buffer) => {
-          const compressedBase64 = this.blobToB64(buffer)
+      if (points[i].enqueuedAt !== undefined) {
+        metadata['enqueued-at'] = points[i].enqueuedAt
 
-          console.log(`[rex-passive-data-kit] Upload to "${this.uploadUrl}"...`)
+        delete points[i].enqueuedAt
+      }
 
-          fetch(this.uploadUrl, {
-            method: 'POST',
-            mode: 'cors', // no-cors, *cors, same-origin
-            cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
-            headers: {
-              'Content-Type': 'application/x-www-form-urlencoded',
-              'X-PDK-IDENTIFIER': this.identifier
-            },
-            redirect: 'follow', // manual, *follow, error
-            referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
-            body: new URLSearchParams({
-              compression: 'gzip',
-              payload: compressedBase64
-            })
-          }) // body data type must match "Content-Type" header
-            .then((response) => {
-              response.json().then((reply) => {
-                if (response.ok) {
-                  resolve(reply)
-                } else {
-                  reject(reply)
-                }
-              })
-            })
-            .catch((error) => {
-              console.error('Error:', error)
+      if (points[i].date === undefined) {
+        points[i].date = (new Date()).getTime()
+      }
 
-              reject(error)
-            })
-        })
+      // metadata['generated-key'] = nacl.util.encodeBase64(keyPair.publicKey)
+
+      points[i]['passive-data-metadata'] = metadata
+
+      // pdk.encryptFields(serverPublicKey, keyPair.secretKey, points[i])
+    }
+  }
+
+  async gzipUtf8(payload: string): Promise<ArrayBuffer> {
+    const stream = new Blob([payload])
+      .stream()
+      .pipeThrough(new CompressionStream('gzip'))
+
+    return await new Response(stream).arrayBuffer()
+  }
+
+  // An empty body on a 2xx is a success, not a parse failure: edge caches ahead
+  // of the ingest endpoint answer a stored PUT with no content at all.
+  async jsonReplyOrDefault(response: Response): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const text = await response.text()
+
+    if (text.trim() === '') {
+      return PDK_UPLOAD_SUCCESS_REPLY
+    }
+
+    try {
+      return JSON.parse(text)
+    } catch (error) {
+      if (response.ok) {
+        return PDK_UPLOAD_SUCCESS_REPLY
+      }
+
+      return {
+        error: text,
+        parse_error: `${error}`,
+      }
+    }
+  }
+
+  async uploadBundle(points:REXPDKDataPoint[]) {
+    if (this.ignoredIdentifiers.includes(this.identifier)) {
+      console.log(`[rex-passive-data-kit] Skipping upload for ignored identifier "${this.identifier}".`)
+
+      return PDK_UPLOAD_SUCCESS_REPLY
+    }
+
+    this.stampPointMetadata(points)
+
+    const compressed = await this.gzipUtf8(JSON.stringify(points, null, 2))
+
+    if (this.endpointVersion === 'v3') {
+      return this.putBundle(compressed)
+    }
+
+    return this.postBundle(compressed)
+  }
+
+  // v3 ingest: raw gzip bytes with a bearer credential, identifying the
+  // participant by header so no token or identifier lands in the URL.
+  async putBundle(compressed: ArrayBuffer) {
+    if (this.uploadUrl === '') {
+      throw new Error('Unable to upload data bundle: passive_data_kit.endpoint is missing.')
+    }
+
+    if (this.bearerToken === '') {
+      throw new Error('Unable to upload data bundle: passive_data_kit.authorization.token is missing.')
+    }
+
+    if (this.identifier === '' || this.identifier.toLowerCase() === 'undefined') {
+      throw new Error('Unable to upload data bundle: participant identifier is missing.')
+    }
+
+    console.log(`[rex-passive-data-kit] Upload to "${this.uploadUrl}"...`)
+
+    const response = await fetch(this.uploadUrl, {
+      method: 'PUT',
+      mode: 'cors',
+      cache: 'no-cache',
+      headers: {
+        'Authorization': `Bearer ${this.bearerToken}`,
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip',
+        'X-PDK-IDENTIFIER': this.identifier
+      },
+      redirect: 'follow',
+      referrerPolicy: 'no-referrer',
+      body: compressed
     })
+
+    const reply = await this.jsonReplyOrDefault(response)
+
+    if (response.ok === false) {
+      throw new REXPDKUploadError(response.status, reply)
+    }
+
+    return reply
+  }
+
+  async postBundle(compressed: ArrayBuffer) {
+    const compressedBase64 = this.blobToB64(compressed)
+
+    console.log(`[rex-passive-data-kit] Upload to "${this.uploadUrl}"...`)
+
+    const response = await fetch(this.uploadUrl, {
+      method: 'POST',
+      mode: 'cors', // no-cors, *cors, same-origin
+      cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-PDK-IDENTIFIER': this.identifier
+      },
+      redirect: 'follow', // manual, *follow, error
+      referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+      body: new URLSearchParams({
+        compression: 'gzip',
+        payload: compressedBase64
+      })
+    }) // body data type must match "Content-Type" header
+
+    const reply = await this.jsonReplyOrDefault(response)
+
+    if (response.ok === false) {
+      throw new REXPDKUploadError(response.status, reply)
+    }
+
+    return reply
   }
 
   updateDataPoints(dataPoints: REXPDKDataPointDBRecord[]) {

--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -439,7 +439,32 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
     }
   }
 
+  // Deployments that issue the participant identifier through rex-core rather
+  // than through passive_data_kit.identifier leave the configured value unset;
+  // the server may even strip the key when it injects upload credentials. Fall
+  // back to rex-core, which owns the identifier, instead of uploading under the
+  // placeholder.
+  async resolveIdentifier(): Promise<string> {
+    if (this.identifier !== '' && this.identifier !== 'unknown-id') {
+      return this.identifier
+    }
+
+    const identifier = await new Promise<string>((resolve) => {
+      rexCorePlugin.handleMessage({ messageType: 'getIdentifier' }, this, (response: string) => {
+        resolve(response)
+      })
+    })
+
+    if (typeof identifier === 'string' && identifier !== '') {
+      this.identifier = identifier
+    }
+
+    return this.identifier
+  }
+
   async uploadBundle(points:REXPDKDataPoint[]) {
+    await this.resolveIdentifier()
+
     if (this.ignoredIdentifiers.includes(this.identifier)) {
       console.log(`[rex-passive-data-kit] Skipping upload for ignored identifier "${this.identifier}".`)
 

--- a/tests/scripts/run-server.js
+++ b/tests/scripts/run-server.js
@@ -7,10 +7,54 @@ import multer from 'multer'
 const app = express();
 const port = 9090;
 
-app.use(express.json()) // for parsing application/json
-app.use(express.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
+// The v3 bundle PUT sends gzip bytes under a Content-Type of application/json,
+// which the global JSON parser would consume before the route's raw parser sees
+// it. Skip both global parsers for that one request shape.
+const isRawBundleUpload = (request) => request.method === 'PUT' && request.path === '/data/add-bundle.json'
+
+const skipRawBundleUpload = (parser) => (request, response, next) => {
+  if (isRawBundleUpload(request)) {
+    return next()
+  }
+
+  return parser(request, response, next)
+}
+
+app.use(skipRawBundleUpload(express.json())) // for parsing application/json
+app.use(skipRawBundleUpload(express.urlencoded({ extended: true }))) // for parsing application/x-www-form-urlencoded
 
 const upload = multer()
+
+// Specs exercising a bearer admission failure send anything else.
+const VALID_BEARER_TOKEN = 'local-test-bearer-token'
+
+// Every ingest route holds points to the same envelope contract. Returns an
+// error string, or null when the bundle is well formed.
+const validateDataPoints = (dataPoints) => {
+  for (const dataPoint of dataPoints) {
+    const metadata = dataPoint['passive-data-metadata']
+
+    if (metadata === undefined) {
+      return '<passive-data-metadata> is missing.'
+    }
+
+    if (metadata.source === undefined) {
+      return '<passive-data-metadata.source> is missing.'
+    }
+
+    if (metadata['configuration-hash'] === undefined) {
+      return '<passive-data-metadata.configuration-hash> is missing.'
+    }
+
+    // enqueuedAt belongs in the metadata envelope as enqueued-at; leaving it on
+    // the point body means an uploader skipped the shared stamping step.
+    if (dataPoint.enqueuedAt !== undefined) {
+      return '<enqueuedAt> leaked into the data point body.'
+    }
+  }
+
+  return null
+}
 
 app.get('/', (request, response) => {
   response.send('The only way to pass a test is to take the test.')
@@ -54,34 +98,72 @@ app.post('/data/add-bundle.json', upload.none(), (request, response) => {
 
   console.error(`/data/add-bundle.json: ${JSON.stringify(reply, null, '  ')}`)
 
-  for (const dataPoint of reply.payload) {
-    const metadata = dataPoint['passive-data-metadata']
+  const error = validateDataPoints(reply.payload)
 
-    let error = null
+  if (error !== null) {
+    console.error(`Error encountered in data point: ${error}`)
+    console.error(`/data/add-bundle.json: ${JSON.stringify(reply.payload, null, '  ')}`)
 
-    if (metadata === undefined) {
-      error = '<passive-data-metadata> is missing.'
-    }
+    response.statusCode = 400;
+    response.send(JSON.stringify({'error': error}))
 
-    if (metadata.source === undefined) {
-      error = '<passive-data-metadata.source> is missing.'
-    }
-
-    if (metadata['configuration-hash'] === undefined) {
-      error = '<passive-data-metadata.configuration-hash> is missing.'
-    }
-
-    if (error !== null) {
-      console.error(`Error encountered in data point: ${error}`)
-      console.error(`/data/add-bundle.json: ${JSON.stringify(dataPoint, null, '  ')}`)
-      
-      response.statusCode = 400;
-      response.send(JSON.stringify({'error': '"passive-data-metadata.source" is missing.'}))
-
-      return
-    }
+    return
   }
 
+  response.send(JSON.stringify(reply, null, '  '))
+})
+
+// The v3 bundle upload PUTs raw gzip bytes rather than a base64 payload field,
+// so this route parses its own raw body. A global raw parser would swallow the
+// urlencoded bodies the POST routes above depend on.
+app.put('/data/add-bundle.json', express.raw({ type: '*/*', limit: '10mb' }), (request, response) => {
+  response.setHeader('Content-Type', 'application/json')
+
+  const authorization = request.headers['authorization']
+
+  if (authorization !== `Bearer ${VALID_BEARER_TOKEN}`) {
+    console.error(`PUT /data/add-bundle.json: rejecting authorization "${authorization}"`)
+
+    response.statusCode = 401
+    response.send(JSON.stringify({ 'error': 'Invalid or missing bearer token.' }))
+
+    return
+  }
+
+  let payload = null
+
+  try {
+    // express.raw() inflates a gzip Content-Encoding itself, so request.body is
+    // already plain JSON bytes by the time it gets here.
+    payload = JSON.parse(request.body.toString())
+  } catch (error) {
+    console.error(`PUT /data/add-bundle.json: unable to decode body: ${error}`)
+
+    response.statusCode = 400
+    response.send(JSON.stringify({ 'error': `Unable to decode body: ${error}` }))
+
+    return
+  }
+
+  const reply = {
+    'request-headers': request.headers,
+    'payload': payload
+  }
+
+  console.error(`PUT /data/add-bundle.json: ${JSON.stringify(reply, null, '  ')}`)
+
+  const error = validateDataPoints(payload)
+
+  if (error !== null) {
+    console.error(`Error encountered in data point: ${error}`)
+
+    response.statusCode = 400
+    response.send(JSON.stringify({ 'error': error }))
+
+    return
+  }
+
+  response.statusCode = 200
   response.send(JSON.stringify(reply, null, '  '))
 })
 

--- a/tests/specs/serviceworker-v3-put.spec.ts
+++ b/tests/specs/serviceworker-v3-put.spec.ts
@@ -163,6 +163,32 @@ test('an ignored identifier resolves without uploading', async ({serviceWorker})
   expect(reply === undefined || reply['request-headers'] === undefined).toBe(true)
 })
 
+test('an identifier absent from configuration falls back to rex-core', async ({serviceWorker}) => {
+  // The server strips passive_data_kit.identifier when it injects v3 upload
+  // credentials, so the module must source the participant id from rex-core or
+  // it uploads everything under the "unknown-id" placeholder.
+  const identifierlessConfiguration = {
+    endpoint: ENDPOINT,
+    endpoint_version: 'v3',
+    authorization: { token: VALID_BEARER_TOKEN }
+  }
+
+  const result = await serviceWorker.evaluate(async ([configuration]) => {
+    const pdk = self.rexPDKPlugin
+
+    await new Promise((resolve) => {
+      self.rexCorePlugin.handleMessage({ messageType: 'setIdentifier', identifier: 'core-issued-id' }, this, resolve)
+    })
+
+    pdk.identifier = 'unknown-id'
+    pdk.updateConfiguration(configuration)
+
+    return pdk.resolveIdentifier()
+  }, [identifierlessConfiguration])
+
+  expect(result).toEqual('core-issued-id')
+})
+
 // The drift this extraction fixes: Keystone's copy of the stamping loop moved
 // neither half of enqueuedAt, so points shipped without enqueued-at metadata AND
 // with a stray enqueuedAt key still on the body. Both transports must do both.

--- a/tests/specs/serviceworker-v3-put.spec.ts
+++ b/tests/specs/serviceworker-v3-put.spec.ts
@@ -1,0 +1,181 @@
+// @ts-nocheck
+
+import { test, expect } from './fixtures';
+
+// The v3 upload path PUTs raw gzip bytes with a bearer token instead of POSTing
+// a base64 payload field. These specs drive the module's configuration directly
+// rather than editing tests/extension/config.json, so the default POST transport
+// stays in place for every other spec.
+
+const VALID_BEARER_TOKEN = 'local-test-bearer-token'
+const ENDPOINT = 'http://localhost:9090/data/add-bundle.json'
+
+const V3_CONFIGURATION = {
+  identifier: 'rex-pdk',
+  endpoint: ENDPOINT,
+  endpoint_version: 'v3',
+  authorization: { token: VALID_BEARER_TOKEN }
+}
+
+const LEGACY_CONFIGURATION = {
+  identifier: 'rex-pdk',
+  endpoint: ENDPOINT
+}
+
+// Waits for setup() to open the database and the initial configuration fetch to
+// land, then replaces that configuration with the one the spec needs and drains
+// a single freshly enqueued point.
+const uploadPointWith = (serviceWorker, configuration, generatorId) => {
+  return serviceWorker.evaluate(async ([configuration, generatorId]) => {
+    const pdk = self.rexPDKPlugin
+
+    // Awaits the condition, so async predicates (an IndexedDB count, say) are
+    // resolved rather than treated as an always-truthy Promise.
+    const waitFor = async (condition, timeoutMs, label) => {
+      const started = Date.now()
+
+      while ((await condition()) === false) {
+        if (Date.now() - started > timeoutMs) {
+          throw new Error(`Timed out waiting for: ${label}`)
+        }
+
+        await new Promise((resolve) => self.setTimeout(resolve, 25))
+      }
+    }
+
+    await waitFor(() => pdk.database !== null && pdk.uploadUrl !== '', 10000, 'database open and configuration loaded')
+
+    const untransmittedCount = () => {
+      return new Promise<number>((resolve) => {
+        const request = pdk.database.transaction(['dataPoints'], 'readonly')
+          .objectStore('dataPoints')
+          .index('transmitted')
+          .count(0)
+
+        request.onsuccess = () => resolve(request.result)
+      })
+    }
+
+    // setup() kicks off its own drain via refreshConfiguration(). Waiting on
+    // currentlyUploading is not enough: it reads false both before that drain
+    // starts and after it ends. Wait for the queue itself to empty, so this
+    // spec's point is the only untransmitted one when it drains below.
+    await waitFor(async () => (await untransmittedCount()) === 0, 15000, 'startup queue drained')
+
+    pdk.updateConfiguration(configuration)
+
+    pdk.enqueueDataPoint(generatorId, { 'test': 'v3' })
+
+    // Wait for the point to be durable AND still untransmitted. Checking
+    // queuedPoints alone is not enough: it empties the moment the point is
+    // persisted, which can be before the startup drain's in-flight upload
+    // returns and sweeps this point into that batch.
+    await waitFor(async () => (await untransmittedCount()) === 1, 5000, 'point persisted and awaiting upload')
+
+    try {
+      const responses = await pdk.uploadQueuedDataPoints(() => {})
+
+      return { ok: true, responses, untransmitted: await untransmittedCount() }
+    } catch (error) {
+      return { ok: false, error: `${error}`, untransmitted: await untransmittedCount() }
+    }
+  }, [configuration, generatorId])
+}
+
+test('v3 configuration PUTs a gzipped bundle with bearer authorization', async ({serviceWorker}) => {
+  const result = await uploadPointWith(serviceWorker, V3_CONFIGURATION, 'v3-put-test')
+
+  expect(result.ok).toBe(true)
+
+  const headers = result.responses[0]['request-headers']
+
+  expect(headers['authorization']).toEqual(`Bearer ${VALID_BEARER_TOKEN}`)
+  expect(headers['content-type']).toEqual('application/json')
+  expect(headers['content-encoding']).toEqual('gzip')
+  expect(headers['x-pdk-identifier']).toEqual('rex-pdk')
+
+  const uploaded = result.responses[0].payload.find((point) => point['passive-data-metadata']['generator-id'] === 'v3-put-test')
+
+  expect(uploaded).toBeDefined()
+  expect(uploaded['test']).toEqual('v3')
+  expect(uploaded['passive-data-metadata'].source).toEqual('rex-pdk')
+})
+
+test('configuration without endpoint_version still POSTs the legacy payload', async ({serviceWorker}) => {
+  const result = await uploadPointWith(serviceWorker, LEGACY_CONFIGURATION, 'legacy-post-test')
+
+  expect(result.ok).toBe(true)
+
+  // The legacy route echoes the urlencoded request body; the v3 route has no
+  // such field. Its presence is what proves the POST transport ran.
+  expect(result.responses[0]['request-body'].compression).toEqual('gzip')
+
+  const uploaded = result.responses[0].payload.find((point) => point['passive-data-metadata']['generator-id'] === 'legacy-post-test')
+
+  expect(uploaded).toBeDefined()
+})
+
+test('a rejected bearer token leaves the bundle queued', async ({serviceWorker}) => {
+  const staleTokenConfiguration = {
+    ...V3_CONFIGURATION,
+    authorization: { token: 'stale-token' }
+  }
+
+  const result = await uploadPointWith(serviceWorker, staleTokenConfiguration, 'v3-stale-token-test')
+
+  expect(result.ok).toBe(false)
+  expect(result.untransmitted).toBeGreaterThan(0)
+})
+
+test('v3 configuration without an authorization token uploads nothing', async ({serviceWorker}) => {
+  const tokenlessConfiguration = {
+    identifier: 'rex-pdk',
+    endpoint: ENDPOINT,
+    endpoint_version: 'v3'
+  }
+
+  const result = await uploadPointWith(serviceWorker, tokenlessConfiguration, 'v3-tokenless-test')
+
+  expect(result.ok).toBe(false)
+  expect(result.error).toContain('authorization.token')
+  expect(result.untransmitted).toBeGreaterThan(0)
+})
+
+test('an ignored identifier resolves without uploading', async ({serviceWorker}) => {
+  const ignoredConfiguration = {
+    ...V3_CONFIGURATION,
+    identifier: 'store-review-install',
+    ignored_identifiers: ['store-review-install']
+  }
+
+  const result = await uploadPointWith(serviceWorker, ignoredConfiguration, 'v3-ignored-test')
+
+  // Resolving marks the points transmitted, so the queue drains without any
+  // request reaching the server. A rejected upload would strand them instead.
+  expect(result.ok).toBe(true)
+  expect(result.untransmitted).toEqual(0)
+
+  // Draining alone is not evidence: an upload that actually reached the server
+  // would also clear the queue. The server echoes its request headers on every
+  // successful ingest, so an empty reply is what proves nothing was sent.
+  const reply = result.responses[0]
+
+  expect(reply === undefined || reply['request-headers'] === undefined).toBe(true)
+})
+
+// The drift this extraction fixes: Keystone's copy of the stamping loop moved
+// neither half of enqueuedAt, so points shipped without enqueued-at metadata AND
+// with a stray enqueuedAt key still on the body. Both transports must do both.
+for (const [label, configuration] of [['v3 PUT', V3_CONFIGURATION], ['legacy POST', LEGACY_CONFIGURATION]]) {
+  test(`${label} moves enqueuedAt into metadata and strips it from the point body`, async ({serviceWorker}) => {
+    const result = await uploadPointWith(serviceWorker, configuration, 'enqueued-at-test')
+
+    expect(result.ok).toBe(true)
+
+    const uploaded = result.responses[0].payload.find((point) => point['passive-data-metadata']['generator-id'] === 'enqueued-at-test')
+
+    expect(uploaded).toBeDefined()
+    expect(uploaded['passive-data-metadata']['enqueued-at']).toEqual(expect.any(Number))
+    expect(uploaded.enqueuedAt).toBeUndefined()
+  })
+}


### PR DESCRIPTION
This is the PUT code that we discussed.

---
Adds the v3 bearer-token PUT upload path to the module, and extracts the point-metadata stamping so both transports share it.

This code currently lives in a client extension, which monkey-patches uploadBundle to replace the legacy form-POST uploader. Moving it here means the transport is framework code rather than per-client code, and the duplicated envelope logic collapses to one copy.

Changes

- REXPDKConfiguration gains endpoint_version, authorization.token, ignored_identifiers
- stampPointMetadata() extracted from uploadBundle — previously inline, now shared by both transports
- uploadBundle() becomes a dispatcher: endpoint_version: 'v3' → putBundle() (raw gzip bytes, Authorization: Bearer, X-PDK-IDENTIFIER), otherwise → postBundle() (existing base64 + urlencoded POST, unchanged)
- jsonReplyOrDefault() — both paths now treat an empty 2xx as success. The POST path previously called bare response.json(), which throws on an empty body
- REXPDKUploadError exported, carrying status so callers can distinguish a 401/403 admission failure from a transport error
- resolveIdentifier() falls back to rex-core's getIdentifier when config omits identifier — some deployments strip that key server-side when injecting upload credentials

Additive: with no endpoint_version in config, behavior is byte-identical to before.

Why the metadata extraction is part of this

The client's copy of the stamping loop had drifted: it handled configurationHash but not enqueuedAt, so points shipped without enqueued-at metadata and with a stray enqueuedAt left on the body. Two copies of the same rules are what caused it, so this PR removes the second copy rather than adding a third.

Tests

7 new specs in tests/specs/serviceworker-v3-put.spec.ts: PUT wire contract, legacy POST regression, queue retention on bearer rejection, fail-closed on missing token, ignored-identifier skip, rex-core identifier fallback, and enqueuedAt handling asserted on both transports (metadata present and body key stripped).

tests/scripts/run-server.js gains a PUT /data/add-bundle.json route. Two things worth knowing if you touch it: the global express.json() parser had to be scoped out of that route (the PUT sends gzip bytes under Content-Type: application/json, so the JSON parser claimed the body first), and express.raw() inflates gzip itself — no manual gunzip. The POST route's inline validation moved into a shared validateDataPoints() so both transports are held to one contract.

Verification

npm run build, npm run lint, npm test — all exit 0, 13 passed. Bundle verified fresh and containing the changes before trusting the result.

The enqueuedAt guard was mutation-tested: removing the stamping block reproduces the client's drift and fails the suite on both transports, server-side.

Downstream integration: the client extension was pinned to this branch, its override rewritten to delegate transport, and its full suite passes (130 passed, 0 failed). Not verified against a real backend — the mock server only proves the wire shape.