### PR TITLE
add v3 bearer PUT upload path selected by endpoint_version

### DIFF
--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -50,6 +50,29 @@ export interface REXPDKConfiguration {
   endpoint: string,
   identifier: string,
   field_key?: string,
+  // 'v3' uploads bundles with PUT and a bearer credential. Any other value (or
+  // none) uses the legacy form-encoded POST. There is deliberately no fallback
+  // between the two: a server that only accepts v3 can only reject a POST, so
+  // failing loudly and leaving the bundle queued beats silently downgrading.
+  endpoint_version?: string,
+  authorization?: REXPDKAuthorization,
+}
+
+export interface REXPDKAuthorization {
+  token?: string,
+}
+
+export class REXPDKUploadError extends Error {
+  status: number
+  responseBody: unknown
+
+  constructor(status: number, responseBody: unknown) {
+    super(`Data bundle upload failed with HTTP ${status}.`)
+
+    this.name = 'REXPDKUploadError'
+    this.status = status
+    this.responseBody = responseBody
+  }
 }
 
 export interface REXPDKEvent {
@@ -73,6 +96,8 @@ export class PassiveDataKitPointAnnotator {
 
 class PassiveDataKitModule extends REXServiceWorkerModule {
   uploadUrl: string = ''
+  endpointVersion: string = ''
+  bearerToken: string = ''
   serverKey: string = ''
   serverFieldKey: Uint8Array<ArrayBufferLike> | null = null
   localFieldKey: Uint8Array<ArrayBufferLike> | null = null
@@ -136,7 +161,12 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
 
   updateConfiguration(config: REXPDKConfiguration) {
     this.uploadUrl = config['endpoint']
-    
+
+    // Validated at upload time, not here: a refresh that threw on a malformed
+    // credential would wedge the module on a stale endpoint.
+    this.endpointVersion = config['endpoint_version'] || ''
+    this.bearerToken = config['authorization']?.token || ''
+
     if (config['identifier'] !== undefined && config['identifier'] !== null) {
       this.identifier = config['identifier']
     } else {
@@ -326,53 +356,145 @@ class PassiveDataKitModule extends REXServiceWorkerModule {
     })
   }
 
-  async uploadBundle(points:REXPDKDataPoint[]) {
-    return new Promise<any>((resolve, reject) => { // eslint-disable-line @typescript-eslint/no-explicit-any
-      const manifest = chrome.runtime.getManifest()
+  // Moves the enqueue-time fields the module stamps on each point into the
+  // server-facing 'passive-data-metadata' envelope. Shared by both transports:
+  // an override that reimplements this drifts from it (see Keystone's copy,
+  // which missed 'enqueued-at' for a month).
+  stampPointMetadata(points:REXPDKDataPoint[]) {
+    const manifest = chrome.runtime.getManifest()
 
+    const userAgent = manifest.name + '/' + manifest.version + ' ' + navigator.userAgent
+
+    for (let i = 0; i < points.length; i++) {
+      let pointDate:number|undefined = points[i].date
+
+      if (pointDate === undefined) {
+        pointDate = Date.now()
+      }
+
+      const metadata: REXPDKPointMetadata = {
+        source: `${this.identifier}`,
+        generator: points[i].generatorId + ': ' + userAgent,
+        'generator-id': points[i].generatorId,
+        timestamp: pointDate / 1000,
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      }
+
+      if (points[i].configurationHash !== undefined) {
+        metadata['configuration-hash'] = points[i].configurationHash
+
+        delete points[i].configurationHash
+      }
+
+      if (points[i].enqueuedAt !== undefined) {
+        metadata['enqueued-at'] = points[i].enqueuedAt
+
+        delete points[i].enqueuedAt
+      }
+
+      if (points[i].date === undefined) {
+        points[i].date = (new Date()).getTime()
+      }
+
+      points[i]['passive-data-metadata'] = metadata
+    }
+  }
+
+  async uploadBundle(points:REXPDKDataPoint[]) {
+    this.stampPointMetadata(points)
+
+    if (this.endpointVersion === 'v3') {
+      return this.putBundle(points)
+    }
+
+    return this.postBundle(points)
+  }
+
+  // v3 ingest: raw gzip bytes authorized by a bearer credential, with the
+  // participant identified by header so neither token nor identifier lands in
+  // the URL.
+  async putBundle(points:REXPDKDataPoint[]) {
+    if (this.uploadUrl === '') {
+      throw new Error('Unable to upload data bundle: passive_data_kit.endpoint is missing.')
+    }
+
+    if (this.bearerToken === '') {
+      throw new Error('Unable to upload data bundle: passive_data_kit.authorization.token is missing.')
+    }
+
+    if (this.identifier === '' || this.identifier === 'undefined') {
+      throw new Error('Unable to upload data bundle: participant identifier is missing.')
+    }
+
+    const stream = new Blob([JSON.stringify(points, null, 2)])
+      .stream()
+      .pipeThrough(new CompressionStream('gzip'))
+
+    const body = await new Response(stream).arrayBuffer()
+
+    console.log(`[rex-passive-data-kit] Upload to "${this.uploadUrl}"...`)
+
+    const response = await fetch(this.uploadUrl, {
+      method: 'PUT',
+      mode: 'cors',
+      cache: 'no-cache',
+      headers: {
+        'Authorization': `Bearer ${this.bearerToken}`,
+        'Content-Type': 'application/json',
+        'Content-Encoding': 'gzip',
+        'X-PDK-IDENTIFIER': this.identifier
+      },
+      redirect: 'follow',
+      referrerPolicy: 'no-referrer',
+      body
+    })
+
+    const reply = await this.replyOrAccepted(response)
+
+    if (response.ok === false) {
+      throw new REXPDKUploadError(response.status, reply)
+    }
+
+    return reply
+  }
+
+  // A 2xx with no body is an accepted bundle, not a parse failure: caches ahead
+  // of the ingest endpoint answer a stored PUT with no content at all.
+  async replyOrAccepted(response: Response): Promise<any> { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const text = await response.text()
+
+    if (text.trim() === '') {
+      return {
+        message: 'Data bundle added successfully, and ready for processing.',
+        added: true
+      }
+    }
+
+    try {
+      return JSON.parse(text)
+    } catch (error) {
+      if (response.ok) {
+        return {
+          message: 'Data bundle added successfully, and ready for processing.',
+          added: true
+        }
+      }
+
+      return {
+        error: text,
+        parse_error: `${error}`
+      }
+    }
+  }
+
+  async postBundle(points:REXPDKDataPoint[]) {
+    return new Promise<any>((resolve, reject) => { // eslint-disable-line @typescript-eslint/no-explicit-any
       const keyPair = nacl.box.keyPair() // eslint-disable-line @typescript-eslint/no-unused-vars
 
       const serverPublicKey = naclUtil.decodeBase64(this.serverKey) // eslint-disable-line @typescript-eslint/no-unused-vars
 
-      const userAgent = manifest.name + '/' + manifest.version + ' ' + navigator.userAgent
-
-      for (let i = 0; i < points.length; i++) {
-        let pointDate:number|undefined = points[i].date
-
-        if (pointDate === undefined) {
-          pointDate = Date.now()
-        }
-
-        const metadata: REXPDKPointMetadata = {
-          source: `${this.identifier}`,
-          generator: points[i].generatorId + ': ' + userAgent,
-          'generator-id': points[i].generatorId,
-          timestamp: pointDate / 1000,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        }
-
-        if (points[i].configurationHash !== undefined) {
-          metadata['configuration-hash'] = points[i].configurationHash
-
-          delete points[i].configurationHash
-        }
-
-        if (points[i].enqueuedAt !== undefined) {
-          metadata['enqueued-at'] = points[i].enqueuedAt
-
-          delete points[i].enqueuedAt
-        }
-
-        if (points[i].date === undefined) {
-          points[i].date = (new Date()).getTime()
-        }
-
-        // metadata['generated-key'] = nacl.util.encodeBase64(keyPair.publicKey)
-
-        points[i]['passive-data-metadata'] = metadata
-
-        // pdk.encryptFields(serverPublicKey, keyPair.secretKey, points[i])
-      }
+      // pdk.encryptFields(serverPublicKey, keyPair.secretKey, points[i])
+      // metadata['generated-key'] = nacl.util.encodeBase64(keyPair.publicKey)
 
       const dataString = JSON.stringify(points, null, 2)
 

--- a/tests/scripts/run-server.js
+++ b/tests/scripts/run-server.js
@@ -7,6 +7,14 @@ import multer from 'multer'
 const app = express();
 const port = 9090;
 
+// Registered ahead of the JSON/urlencoded parsers and scoped to the v3 routes:
+// those receive raw gzip bytes, which express.json() would otherwise consume
+// (leaving nothing for a later raw parser to read).
+// Scoped to /v3 and registered ahead of the JSON/urlencoded parsers, which would
+// otherwise consume the body. body-parser honors Content-Encoding and hands the
+// route an already-decompressed buffer, same as the real ingest endpoint.
+app.use('/v3', express.raw({ type: '*/*', limit: '50mb' }))
+
 app.use(express.json()) // for parsing application/json
 app.use(express.urlencoded({ extended: true })) // for parsing application/x-www-form-urlencoded
 
@@ -83,6 +91,69 @@ app.post('/data/add-bundle.json', upload.none(), (request, response) => {
   }
 
   response.send(JSON.stringify(reply, null, '  '))
+})
+
+app.put('/v3/data/bundle', (request, response) => {
+  response.setHeader('Content-Type', 'application/json')
+
+  const authorization = request.headers['authorization']
+
+  if (authorization !== 'Bearer test-bearer-token') {
+    response.statusCode = 401;
+    response.send(JSON.stringify({'error': 'Missing or invalid bearer token.'}))
+
+    return
+  }
+
+  if (request.headers['content-encoding'] !== 'gzip') {
+    response.statusCode = 400;
+    response.send(JSON.stringify({'error': 'Bundle was not gzip-encoded.'}))
+
+    return
+  }
+
+  const payload = JSON.parse(Buffer.from(request.body).toString())
+
+  console.error(`/v3/data/bundle: ${JSON.stringify(payload, null, '  ')}`)
+
+  for (const dataPoint of payload) {
+    const metadata = dataPoint['passive-data-metadata']
+
+    let error = null
+
+    if (metadata === undefined) {
+      error = '<passive-data-metadata> is missing.'
+    } else if (metadata.source === undefined) {
+      error = '<passive-data-metadata.source> is missing.'
+    } else if (metadata['enqueued-at'] === undefined && dataPoint['generatorId'] !== 'pdk-system-status') {
+      // pdk-system-status points are synthesized during upload rather than
+      // enqueued, so they never carry an enqueuedAt to promote. Same on the
+      // legacy POST path; not specific to v3.
+      error = '<passive-data-metadata.enqueued-at> is missing.'
+    }
+
+    if (error !== null) {
+      console.error(`Error encountered in data point: ${error}`)
+
+      response.statusCode = 400;
+      response.send(JSON.stringify({'error': error}))
+
+      return
+    }
+  }
+
+  response.statusCode = 200;
+  response.send(JSON.stringify({
+    'request-headers': request.headers,
+    'payload': payload
+  }, null, '  '))
+})
+
+// An edge cache ahead of the ingest endpoint answers a stored PUT with no body
+// at all; the client must read that as success, not as a parse failure.
+app.put('/v3/data/bundle-empty-reply', (request, response) => {
+  response.statusCode = 200;
+  response.send('')
 })
 
 app.post('/data/add-point.json', upload.none(), (request, response) => {

--- a/tests/specs/serviceworker-v3-upload.spec.ts
+++ b/tests/specs/serviceworker-v3-upload.spec.ts
@@ -1,0 +1,106 @@
+// @ts-nocheck
+
+import { test, expect } from './fixtures';
+
+const V3_ENDPOINT = 'http://localhost:9090/v3/data/bundle'
+const V3_EMPTY_REPLY_ENDPOINT = 'http://localhost:9090/v3/data/bundle-empty-reply'
+
+// Reconfigure the module in-place rather than editing tests/extension/config.json,
+// which the POST specs share.
+//
+// setup() -> refreshConfiguration() drains the queue on its own, so the event is
+// logged only after reconfiguring and the upload is retried until a bundle
+// actually goes out. Otherwise the setup-triggered POST empties the queue first
+// and this asserts against an empty response set.
+const uploadWithConfiguration = (serviceWorker, configuration) => {
+  return serviceWorker.evaluate(async (pdkConfiguration) => {
+    const sleep = (ms) => new Promise((wake) => setTimeout(wake, ms))
+
+    await sleep(2000)
+
+    self.rexPDKPlugin.updateConfiguration(pdkConfiguration)
+
+    await new Promise((logged) => {
+      self.rexCorePlugin.handleMessage({
+        'messageType': 'logEvent',
+        'event': {
+          'name': 'rex-pdk-v3-test'
+        }
+      }, this, () => {
+        logged(undefined)
+      })
+    })
+
+    for (let attempt = 0; attempt < 10; attempt++) {
+      await sleep(500)
+
+      // A concurrent upload holds the serialization guard; reconfigure each
+      // attempt so a refresh in between cannot revert the endpoint.
+      self.rexPDKPlugin.updateConfiguration(pdkConfiguration)
+
+      try {
+        const response = await self.rexPDKPlugin.uploadQueuedDataPoints(() => {})
+
+        if (Array.isArray(response) && response.length > 0) {
+          return { ok: true, response }
+        }
+      } catch (error) {
+        return { ok: false, error: `${error}` }
+      }
+    }
+
+    return { ok: false, error: 'no bundle was uploaded after 10 attempts' }
+  }, configuration)
+}
+
+test('v3 configuration uploads via PUT with a bearer token', async ({ serviceWorker }) => {
+  const result = await uploadWithConfiguration(serviceWorker, {
+    identifier: 'rex-pdk-v3',
+    endpoint: V3_ENDPOINT,
+    endpoint_version: 'v3',
+    authorization: { token: 'test-bearer-token' }
+  })
+
+  expect(result.ok, `upload failed: ${result.error}`).toBe(true)
+
+  const reply = result.response[0]
+
+  expect(reply['request-headers']['content-encoding']).toEqual('gzip')
+  expect(reply['request-headers']['authorization']).toEqual('Bearer test-bearer-token')
+  expect(reply['request-headers']['x-pdk-identifier']).toEqual('rex-pdk-v3')
+
+  const loggedPoint = reply.payload.find((point) => point['passive-data-metadata']['generator-id'] === 'rex-pdk-v3-test')
+
+  expect(loggedPoint, 'the logged event point was not in the bundle').toBeDefined()
+
+  const metadata = loggedPoint['passive-data-metadata']
+
+  expect(metadata.source).toEqual('rex-pdk-v3')
+  expect(typeof metadata['enqueued-at']).toEqual('number')
+
+  // enqueuedAt is promoted into metadata and removed from the point body.
+  expect(loggedPoint.enqueuedAt).toBeUndefined()
+})
+
+test('v3 configuration without a bearer token fails instead of falling back to POST', async ({ serviceWorker }) => {
+  const result = await uploadWithConfiguration(serviceWorker, {
+    identifier: 'rex-pdk-v3',
+    endpoint: V3_ENDPOINT,
+    endpoint_version: 'v3'
+  })
+
+  expect(result.ok).toBe(false)
+  expect(result.error).toContain('authorization.token')
+})
+
+test('v3 upload treats an empty 2xx reply as success', async ({ serviceWorker }) => {
+  const result = await uploadWithConfiguration(serviceWorker, {
+    identifier: 'rex-pdk-v3',
+    endpoint: V3_EMPTY_REPLY_ENDPOINT,
+    endpoint_version: 'v3',
+    authorization: { token: 'test-bearer-token' }
+  })
+
+  expect(result.ok, `upload failed: ${result.error}`).toBe(true)
+  expect(result.response[0].added).toBe(true)
+})


### PR DESCRIPTION
Adds a v3 bundle upload path (PUT + bearer token) to the module, selected by config. Replaces the earlier `feature/v3-bearer-put-upload` branch, which was flagged for pulling too much client-specific code into the shared module — that branch is abandoned, not rebased.

## Config

```json
"passive_data_kit": {
  "endpoint": "https://.../v3/bundle",
  "endpoint_version": "v3",
  "authorization": { "token": "..." }
}
```

`endpoint_version: "v3"` → PUT with `Authorization: Bearer`, gzip body, participant in the `X-PDK-IDENTIFIER` header. Anything else, or absent → the existing form-encoded POST, byte-for-byte unchanged.

**No fallback between the two, deliberately.** A server that only accepts v3 can only reject a POST, so a failed PUT throws and leaves the bundle queued rather than silently downgrading. This one key is what turns POST off — no separate `post_enabled` flag, so there's no way for two keys to disagree.

## Shared metadata stamping

Extracts `stampPointMetadata()` out of `uploadBundle`, now used by both transports. Consumers that override `uploadBundle` to add their own transport have had to reimplement it, and one copy drifted for a month (missing `enqueued-at` in the metadata envelope, stray `enqueuedAt` left on the point body). Sharing it removes that failure mode.

## Note for consumers overriding `uploadBundle`

`putBundle` reads endpoint, credential and identifier from the module's own fields, which are refreshed on the module's config cycle. An override that resolves configuration itself may be holding something newer (a just-rotated token, or the first config to arrive after install), so it should call `updateConfiguration(...)` before delegating. Found this the hard way: a downstream extension's end-to-end canaries failed because the module was uploading against unset fields while the override had the live config in hand.

Worth a look at whether `uploadBundle` should instead accept an optional configuration argument, which would make this ordering impossible to get wrong. Left out of this PR to keep the signature unchanged.

## Verified

| Gate | Result |
|---|---|
| `npm test` | 8 passed (5 existing + 3 new) |
| `npm run build` (tsc) | clean |
| `npm run lint` | clean |

Confirmed the test bundle contained the change before trusting the run (`putBundle` present, bundle newer than source). `npm test` only, never bare `npx playwright test`.

Three new specs:
- PUT succeeds with bearer + gzip and promotes `enqueued-at` into the metadata envelope
- missing token throws instead of falling back to POST
- empty 2xx body reads as success (caches ahead of the ingest endpoint answer a stored PUT with no content)

Test server gains the two v3 routes. Its raw-body parser is scoped to `/v3` and registered ahead of `express.json()`, which would otherwise consume the gzip body.

## Not in this PR

- Client-specific identifier skipping and identifier-fallback-through-rex-core stayed in the client extension, where that policy belongs.
- `pdk-system-status` points carry no `enqueued-at`. They're constructed inside `uploadQueuedDataPoints` (`src/service-worker.mts:651`) rather than enqueued, so there's no enqueue time to promote. Pre-existing and identical on the POST path; changing it would alter payloads for every consumer. The test server's check is scoped around it. Separate PR pending a decision on whether that field should be non-NULL for these points.
