### PR TITLE
Add regression coverage for point values that structured clone silently drops

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
                 "multer": "^2.2.0",
                 "tweetnacl": "^1.0.3",
                 "tweetnacl-util": "^0.15.1"
+            },
+            "devDependencies": {
+                "@bric/rex-types": "github:bric-digital/rex-types"
             }
         },
         "node_modules/@bric/rex-content-processing": {
@@ -47,6 +50,17 @@
                 "psl": "^1.15.0",
                 "typescript": "^6.0.3",
                 "typescript-eslint": "^8.64.0"
+            }
+        },
+        "node_modules/@bric/rex-types": {
+            "version": "0.0.1",
+            "resolved": "git+ssh://git@github.com/bric-digital/rex-types.git#302de019fd4b6cdbca23df5f6691905a58bf8652",
+            "dev": true,
+            "dependencies": {
+                "@bric/rex-core": "github:bric-digital/rex-core",
+                "@js-temporal/polyfill": "^0.5.1",
+                "@types/check-types": "^11.2.2",
+                "check-types": "^11.2.3"
             }
         },
         "node_modules/@cdssnc/sanitize-pii": {
@@ -649,6 +663,19 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@js-temporal/polyfill": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+            "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "jsbi": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@playwright/test": {
@@ -1976,6 +2003,13 @@
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-4.0.0.tgz",
             "integrity": "sha512-TXCHVR3Lb6TZdtw1l3RTLf8RBWVGexdxL6AC8/e0xZKEpBflBsjh9/8LXw+dkNFuOyW9B7iB3O1sP7hS0Kiacg==",
             "license": "MIT"
+        },
+        "node_modules/jsbi": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+            "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+            "dev": true,
+            "license": "Apache-2.0"
         },
         "node_modules/json-buffer": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
         "multer": "^2.2.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
+    },
+    "devDependencies": {
+        "@bric/rex-types": "github:bric-digital/rex-types"
     }
 }

--- a/tests/scripts/data-point-store.js
+++ b/tests/scripts/data-point-store.js
@@ -13,6 +13,11 @@ export class DataPointStore {
 
   // `dataPoints` is the decoded upload payload: an array for the bundle
   // endpoints, a single point for the add-point endpoint.
+  //
+  // Callers record only after a payload has passed validation. The store stands
+  // for what the server persisted, and a rejected bundle was never written, so
+  // keeping it would report points the server does not have. Do not move these
+  // calls ahead of the 400 paths.
   record(dataPoints) {
     for (const dataPoint of [dataPoints].flat()) {
       this.points.push(dataPoint)

--- a/tests/scripts/data-point-store.js
+++ b/tests/scripts/data-point-store.js
@@ -1,0 +1,43 @@
+// Retains the data points the mock server has accepted so a test can ask what
+// the server actually received, rather than trusting what the client believed
+// it sent. Points are looked up by their `passive-data-metadata.timestamp`
+// (epoch seconds), which a test can pin by setting `date` on the point it
+// enqueues.
+//
+// In-memory and process-lifetime only: the server is started per test run and
+// the store is not meant to outlive it.
+export class DataPointStore {
+  constructor() {
+    this.points = []
+  }
+
+  // `dataPoints` is the decoded upload payload: an array for the bundle
+  // endpoints, a single point for the add-point endpoint.
+  record(dataPoints) {
+    for (const dataPoint of [dataPoints].flat()) {
+      this.points.push(dataPoint)
+    }
+  }
+
+  // A tolerance is accepted because timestamps are floats with sub-millisecond
+  // precision; callers pinning an exact value can leave it at zero.
+  findByTimestamp(timestamp, tolerance = 0) {
+    return this.points.filter((dataPoint) => {
+      const metadata = dataPoint['passive-data-metadata']
+
+      if (metadata === undefined || metadata.timestamp === undefined) {
+        return false
+      }
+
+      return Math.abs(metadata.timestamp - timestamp) <= tolerance
+    })
+  }
+
+  clear() {
+    this.points = []
+  }
+
+  get size() {
+    return this.points.length
+  }
+}

--- a/tests/scripts/data-point-store.js
+++ b/tests/scripts/data-point-store.js
@@ -2,7 +2,11 @@
 // the server actually received, rather than trusting what the client believed
 // it sent. Points are looked up by their `passive-data-metadata.timestamp`
 // (epoch seconds), which a test can pin by setting `date` on the point it
-// enqueues.
+// dispatches.
+//
+// The store holds points, never bundles. A bundle is a transport envelope with
+// no timestamp of its own, so storing one would leave nothing to query by.
+// Bundle routes unwrap and record each point they contain.
 //
 // In-memory and process-lifetime only: the server is started per test run and
 // the store is not meant to outlive it.
@@ -11,16 +15,18 @@ export class DataPointStore {
     this.points = []
   }
 
-  // `dataPoints` is the decoded upload payload: an array for the bundle
-  // endpoints, a single point for the add-point endpoint.
-  //
   // Callers record only after a payload has passed validation. The store stands
   // for what the server persisted, and a rejected bundle was never written, so
   // keeping it would report points the server does not have. Do not move these
   // calls ahead of the 400 paths.
-  record(dataPoints) {
-    for (const dataPoint of [dataPoints].flat()) {
-      this.points.push(dataPoint)
+  recordPoint(dataPoint) {
+    this.points.push(dataPoint)
+  }
+
+  // `dataPoints` is a decoded bundle payload: the array of points it carried.
+  recordPoints(dataPoints) {
+    for (const dataPoint of dataPoints) {
+      this.recordPoint(dataPoint)
     }
   }
 

--- a/tests/scripts/run-server.js
+++ b/tests/scripts/run-server.js
@@ -94,7 +94,7 @@ app.post('/data/add-bundle.json', upload.none(), (request, response) => {
     }
   }
 
-  dataPointStore.record(reply.payload)
+  dataPointStore.recordPoints(reply.payload)
 
   response.send(JSON.stringify(reply, null, '  '))
 })
@@ -148,7 +148,7 @@ app.put('/v3/data/bundle', (request, response) => {
     }
   }
 
-  dataPointStore.record(payload)
+  dataPointStore.recordPoints(payload)
 
   response.statusCode = 200;
   response.send(JSON.stringify({
@@ -204,7 +204,7 @@ app.post('/data/add-point.json', upload.none(), (request, response) => {
     return
   }
 
-  dataPointStore.record(dataPoint)
+  dataPointStore.recordPoint(dataPoint)
 
   const replyMessage = {
     message: 'Data point added successfully.'

--- a/tests/scripts/run-server.js
+++ b/tests/scripts/run-server.js
@@ -4,8 +4,12 @@ import { Buffer } from 'node:buffer';
 import express from 'express'
 import multer from 'multer'
 
+import { DataPointStore } from './data-point-store.js'
+
 const app = express();
 const port = 9090;
+
+const dataPointStore = new DataPointStore()
 
 // Registered ahead of the JSON/urlencoded parsers and scoped to the v3 routes:
 // those receive raw gzip bytes, which express.json() would otherwise consume
@@ -90,6 +94,8 @@ app.post('/data/add-bundle.json', upload.none(), (request, response) => {
     }
   }
 
+  dataPointStore.record(reply.payload)
+
   response.send(JSON.stringify(reply, null, '  '))
 })
 
@@ -141,6 +147,8 @@ app.put('/v3/data/bundle', (request, response) => {
       return
     }
   }
+
+  dataPointStore.record(payload)
 
   response.statusCode = 200;
   response.send(JSON.stringify({
@@ -196,11 +204,69 @@ app.post('/data/add-point.json', upload.none(), (request, response) => {
     return
   }
 
+  dataPointStore.record(dataPoint)
+
   const replyMessage = {
     message: 'Data point added successfully.'
   }
 
   response.send(JSON.stringify(replyMessage, null, '  '))
+})
+
+// Lets a test assert on what the server received rather than on what the client
+// reported sending. `timestamp` is the point's
+// `passive-data-metadata.timestamp` in epoch seconds; `tolerance` widens the
+// match for callers that cannot pin an exact value.
+app.get('/data/points.json', (request, response) => {
+  response.setHeader('Content-Type', 'application/json')
+
+  if (request.query.timestamp === undefined) {
+    response.statusCode = 400;
+    response.send(JSON.stringify({'error': 'Query parameter "timestamp" is required.'}))
+
+    return
+  }
+
+  const timestamp = Number.parseFloat(request.query.timestamp)
+
+  if (Number.isNaN(timestamp)) {
+    response.statusCode = 400;
+    response.send(JSON.stringify({'error': `Query parameter "timestamp" is not a number: ${request.query.timestamp}`}))
+
+    return
+  }
+
+  const tolerance = request.query.tolerance === undefined ? 0 : Number.parseFloat(request.query.tolerance)
+
+  if (Number.isNaN(tolerance)) {
+    response.statusCode = 400;
+    response.send(JSON.stringify({'error': `Query parameter "tolerance" is not a number: ${request.query.tolerance}`}))
+
+    return
+  }
+
+  const points = dataPointStore.findByTimestamp(timestamp, tolerance)
+
+  response.statusCode = 200;
+  response.send(JSON.stringify({
+    'timestamp': timestamp,
+    'tolerance': tolerance,
+    'count': points.length,
+    'points': points
+  }, null, '  '))
+})
+
+// The server outlives any single test, so a test that counts points clears
+// first rather than depending on what ran before it.
+app.delete('/data/points.json', (request, response) => {
+  response.setHeader('Content-Type', 'application/json')
+
+  const cleared = dataPointStore.size
+
+  dataPointStore.clear()
+
+  response.statusCode = 200;
+  response.send(JSON.stringify({'cleared': cleared}))
 })
 
 app.listen(port, () => {

--- a/tests/specs/serviceworker-opaque-point-values.spec.ts
+++ b/tests/specs/serviceworker-opaque-point-values.spec.ts
@@ -20,8 +20,13 @@ import { test, expect } from './fixtures';
 
 const ISO_STAMP = '2026-04-30T17:30:08.089696768Z'
 
+// Pins `passive-data-metadata.timestamp` so the server-side test can retrieve
+// exactly this point. stampPointMetadata derives that field as `date / 1000`.
+const POINT_DATE_MS = 1777570208089
+const POINT_TIMESTAMP = POINT_DATE_MS / 1000
+
 const enqueueOpaquePoint = (serviceWorker, generatorId: string) => {
-  return serviceWorker.evaluate(async ({ generatorId, iso }) => {
+  return serviceWorker.evaluate(async ({ generatorId, iso, dateMs }) => {
     const pdk = self.rexPDKPlugin
 
     const waitFor = (condition: () => boolean, timeoutMs: number, label: string) => {
@@ -53,17 +58,23 @@ const enqueueOpaquePoint = (serviceWorker, generatorId: string) => {
     await waitFor(() => pdk.database !== null && pdk.uploadUrl !== '', 10000, 'database open and configuration loaded')
 
     // Stands in for Temporal.Instant: structured clone sees nothing to copy,
-    // JSON serialization reaches the value through the prototype.
+    // JSON serialization reaches the value through the prototype. Nested under
+    // `value` to match a DateString, which holds its instant that way.
     const opaqueStamp = Object.create({ toJSON: () => iso })
 
     if (Object.keys(opaqueStamp).length !== 0) {
       throw new Error('Test setup invalid: opaqueStamp must have no own enumerable properties.')
     }
 
-    // Mirrors the post-content-processing shape of a DateString: the walker in
-    // rex-content-processing rebuilds objects as plain ones, so the DateString
-    // prototype is already gone and only the inner stamp carries toJSON.
-    pdk.enqueueDataPoint(generatorId, {
+    const before = await countPoints()
+
+    // Goes in the way a real producer does: rex-core's dispatchEvent fans the
+    // event out to every registered module, so this covers logEvent and the
+    // content-processing pass rather than starting at enqueueDataPoint. The
+    // spider reaches PDK by exactly this route.
+    self.rexDispatchEvent({
+      name: generatorId,
+      date: dateMs,
       ended: {
         value: opaqueStamp,
         originalValue: ''
@@ -72,14 +83,14 @@ const enqueueOpaquePoint = (serviceWorker, generatorId: string) => {
 
     const started = Date.now()
 
-    while ((await countPoints()) < 1) {
-      if (Date.now() - started > 5000) {
+    while ((await countPoints()) <= before) {
+      if (Date.now() - started > 8000) {
         throw new Error('Timed out waiting for the point to persist to IndexedDB.')
       }
 
       await new Promise((resolve) => self.setTimeout(resolve, 25))
     }
-  }, { generatorId, iso: ISO_STAMP })
+  }, { generatorId, iso: ISO_STAMP, dateMs: POINT_DATE_MS })
 }
 
 test('a point value reachable only through toJSON survives the persist to IndexedDB', async ({serviceWorker}) => {
@@ -105,23 +116,22 @@ test('a point value reachable only through toJSON survives the persist to Indexe
   expect(persisted['ended']['originalValue']).toEqual('')
 })
 
-test('a point value reachable only through toJSON survives the upload payload', async ({serviceWorker}) => {
-  await enqueueOpaquePoint(serviceWorker, 'opaque-upload-test')
+test('the value the server receives is the timestamp, not an empty object', async ({serviceWorker, request}) => {
+  await enqueueOpaquePoint(serviceWorker, 'opaque-server-test')
 
-  const uploaded = await serviceWorker.evaluate(async (generatorId) => {
-    const responses = await self.rexPDKPlugin.uploadQueuedDataPoints(() => {})
+  await serviceWorker.evaluate(() => self.rexPDKPlugin.uploadQueuedDataPoints(() => {}))
 
-    for (const response of responses) {
-      for (const point of response.payload) {
-        if (point['passive-data-metadata']['generator-id'] === generatorId) {
-          return point
-        }
-      }
-    }
+  // Asking the server what it stored closes the loop the in-worker assertions
+  // leave open: a point can look correct on its way out and still land empty.
+  const response = await request.get(`/data/points.json?timestamp=${POINT_TIMESTAMP}`)
 
-    return null
-  }, 'opaque-upload-test')
+  expect(response.ok()).toBeTruthy()
 
-  expect(uploaded).not.toBeNull()
-  expect(uploaded['ended']['value']).toEqual(ISO_STAMP)
+  const body = await response.json()
+
+  const received = body.points.find((point) => point['passive-data-metadata']['generator-id'] === 'opaque-server-test')
+
+  expect(received).toBeDefined()
+  expect(received['ended']['value']).toEqual(ISO_STAMP)
+  expect(received['ended']['originalValue']).toEqual('')
 })

--- a/tests/specs/serviceworker-opaque-point-values.spec.ts
+++ b/tests/specs/serviceworker-opaque-point-values.spec.ts
@@ -1,140 +1,106 @@
 import { test, expect } from './fixtures';
 
-// These tests pin the defect fixed in 6341080: persisting a point with
+// Pins the defect fixed in 6341080: persisting a point with
 // `objectStore.add(point)` handed the raw object to the structured clone
 // algorithm, which copies only own enumerable properties. A rex-types
-// `DateString` holds its instant in a `Temporal.Instant` from
-// @js-temporal/polyfill, whose state lives in private slots, so the clone
-// wrote `{ value: {}, originalValue: '' }` and the timestamp was gone.
+// `DateString` keeps its instant in a `Temporal.Instant` from
+// @js-temporal/polyfill, whose state lives in private slots, so the clone wrote
+// `{ value: {}, originalValue: '' }` and the timestamp was gone. Nothing raised
+// DataCloneError, so the point persisted, uploaded, and arrived at the server
+// looking well formed. rex-spider-chatgpt writes three DateStrings per
+// conversation and all of them arrived empty.
 //
-// Nothing raised DataCloneError. The point persisted, uploaded, and arrived at
-// the server looking well formed, which is why this ran unnoticed. Asserting on
-// the value is the only thing that catches it.
-//
-// rex-spider-chatgpt writes three DateStrings per conversation (`started`,
-// `ended`, and `when` on every turn), and all of them arrived empty.
-//
-// The tests use the real DateString rather than a local stand-in. A stand-in
-// can only encode what we already believe the type does; if DateString or the
-// polyfill changes shape, an imitation keeps passing while collection breaks.
+// The point travels the queued path a real producer uses, because that is the
+// only path the defect lives on: `transmitSynchronousEvent` goes straight to
+// `transmitDataPoint` and never reaches `objectStore.add`, so a test built on
+// it would pass with or without the fix.
 
 // Epoch seconds, the form ChatGPT emits and DateString accepts.
 const CONVERSATION_EPOCH_SECONDS = 1777570208.089697
 
+// What a DateString holding that instant serializes to. Written out rather than
+// derived from the instance under test, so a change in either the type or the
+// serialization fails here instead of agreeing with itself.
+const CONVERSATION_INSTANT = '2026-04-30T17:30:08.089696768Z'
+
 // stampPointMetadata derives `passive-data-metadata.timestamp` as `date / 1000`,
-// so pinning `date` is what lets the server-side test retrieve this point.
+// so pinning `date` is what makes the point retrievable from the server.
 const POINT_DATE_MS = 1777570208089
 const POINT_TIMESTAMP = POINT_DATE_MS / 1000
 
-const dispatchConversationPoint = (serviceWorker, generatorId: string) => {
-  return serviceWorker.evaluate(async ({ generatorId, epochSeconds, dateMs }) => {
-    const pdk = self.rexPDKPlugin
+const GENERATOR_ID = 'datestring-server-test'
 
-    const waitFor = (condition: () => boolean, timeoutMs: number, label: string) => {
-      return new Promise<void>((resolve, reject) => {
-        const started = Date.now()
+// PDK uploads only when asked, and rejects until its database is open and its
+// configuration has arrived. Retrying absorbs that startup window without the
+// test inspecting the module to find out when it has passed.
+const fetchPointsFromServer = async (serviceWorker, request) => {
+  const deadline = Date.now() + 20000
 
-        const poll = () => {
-          if (condition()) {
-            resolve()
-          } else if (Date.now() - started > timeoutMs) {
-            reject(new Error(`Timed out waiting for: ${label}`))
-          } else {
-            self.setTimeout(poll, 25)
-          }
-        }
-
-        poll()
-      })
-    }
-
-    const countPoints = () => {
-      return new Promise<number>((resolve) => {
-        const request = pdk.database.transaction(['dataPoints'], 'readonly').objectStore('dataPoints').count()
-
-        request.onsuccess = () => resolve(request.result)
-      })
-    }
-
-    await waitFor(() => pdk.database !== null && pdk.uploadUrl !== '', 10000, 'database open and configuration loaded')
-
-    const stamp = new self.rexDateString(epochSeconds)
-
-    // Fails loudly if DateString stops being the thing this test assumes: a
-    // value the structured clone algorithm cannot carry.
-    if (Object.keys(stamp.value).length !== 0) {
-      throw new Error('Test setup invalid: DateString.value now has own enumerable properties, so structured clone would preserve it and this test could no longer fail.')
-    }
-
-    const before = await countPoints()
-
-    // Goes in the way a real producer does: rex-core's dispatchEvent fans the
-    // event out to every registered module, so this covers logEvent and the
-    // content-processing pass rather than starting at enqueueDataPoint. The
-    // spider reaches PDK by exactly this route, with these field names.
-    self.rexDispatchEvent({
-      name: generatorId,
-      date: dateMs,
-      started: stamp,
-      ended: stamp
+  for (;;) {
+    await serviceWorker.evaluate(() => {
+      return self.rexPDKPlugin.uploadQueuedDataPoints(() => {}).then(() => undefined, () => undefined)
     })
 
-    const started = Date.now()
+    const response = await request.get(`/data/points.json?timestamp=${POINT_TIMESTAMP}`)
 
-    while ((await countPoints()) <= before) {
-      if (Date.now() - started > 8000) {
-        throw new Error('Timed out waiting for the point to persist to IndexedDB.')
-      }
+    expect(response.ok()).toBeTruthy()
 
-      await new Promise((resolve) => self.setTimeout(resolve, 25))
+    const body = await response.json()
+
+    if (body.count > 0 || Date.now() > deadline) {
+      return body
     }
 
-    return stamp.toJSON()
-  }, { generatorId, epochSeconds: CONVERSATION_EPOCH_SECONDS, dateMs: POINT_DATE_MS })
+    await new Promise((resolve) => setTimeout(resolve, 250))
+  }
 }
 
-// No content processor is registered in this harness, so the DateString reaches
-// serialization with its prototype intact and its own toJSON flattens it to an
-// ISO string. A consumer that registers one (Keystone registers openredaction)
-// gets `{ value: <iso>, originalValue: '' }` instead, because the processing
-// walker rebuilds objects as plain ones and drops the prototype. Either way the
-// instant survives, and either way the defect replaced it with `{}`.
-test('a DateString on a dispatched point survives the persist to IndexedDB', async ({serviceWorker}) => {
-  const expectedIso = await dispatchConversationPoint(serviceWorker, 'datestring-persist-test')
+// A point dispatched before rex-core has a configuration is dropped:
+// enqueueDataPoint hands the undefined configuration to normalizeConfiguration
+// and the resulting rejection takes the point with it. rex-core's own
+// fetchConfiguration is the public signal for when that window has closed.
+const waitForConfiguration = (serviceWorker) => {
+  return serviceWorker.evaluate(() => {
+    return new Promise<void>((resolve, reject) => {
+      const deadline = Date.now() + 10000
 
-  const persisted = await serviceWorker.evaluate(async (generatorId) => {
-    return new Promise((resolve) => {
-      const request = self.rexPDKPlugin.database.transaction(['dataPoints'], 'readonly').objectStore('dataPoints').getAll()
-
-      request.onsuccess = () => {
-        const record = request.result.find((candidate) => candidate.generatorId === generatorId)
-
-        resolve(record === undefined ? null : record.dataPoint)
+      const poll = () => {
+        self.rexCorePlugin.fetchConfiguration()
+          .then((configuration) => {
+            if (configuration !== undefined && configuration['passive_data_kit'] !== undefined) {
+              resolve()
+            } else if (Date.now() > deadline) {
+              reject(new Error('Timed out waiting for a configuration carrying passive_data_kit.'))
+            } else {
+              self.setTimeout(poll, 100)
+            }
+          })
       }
+
+      poll()
     })
-  }, 'datestring-persist-test')
+  })
+}
 
-  expect(persisted).not.toBeNull()
-  expect(persisted['started']).toEqual(expectedIso)
-  expect(persisted['ended']).toEqual(expectedIso)
-})
+test('a dispatched DateString reaches the server as the instant, not an empty object', async ({serviceWorker, request}) => {
+  await waitForConfiguration(serviceWorker)
 
-test('the DateString the server receives is the instant, not an empty object', async ({serviceWorker, request}) => {
-  const expectedIso = await dispatchConversationPoint(serviceWorker, 'datestring-server-test')
+  await serviceWorker.evaluate(({ generatorId, epochSeconds, dateMs }) => {
+    self.dispatchEvent({
+      name: generatorId,
+      date: dateMs,
+      started: new self.DateString(epochSeconds),
+      ended: new self.DateString(epochSeconds)
+    })
+  }, { generatorId: GENERATOR_ID, epochSeconds: CONVERSATION_EPOCH_SECONDS, dateMs: POINT_DATE_MS })
 
-  await serviceWorker.evaluate(() => self.rexPDKPlugin.uploadQueuedDataPoints(() => {}))
+  const body = await fetchPointsFromServer(serviceWorker, request)
 
-  // Asking the server what it stored closes the loop the in-worker assertions
-  // leave open: a point can look correct on its way out and still land empty.
-  const response = await request.get(`/data/points.json?timestamp=${POINT_TIMESTAMP}`)
+  expect(body.count).toEqual(1)
 
-  expect(response.ok()).toBeTruthy()
+  const received = body.points[0]
 
-  const body = await response.json()
-
-  const received = body.points.find((point) => point['passive-data-metadata']['generator-id'] === 'datestring-server-test')
-
-  expect(received).toBeDefined()
-  expect(received['started']).toEqual(expectedIso)
-  expect(received['ended']).toEqual(expectedIso)
+  expect(received['passive-data-metadata']['generator-id']).toEqual(GENERATOR_ID)
+  expect(received['started']).toEqual(CONVERSATION_INSTANT)
+  expect(received['ended']).toEqual(CONVERSATION_INSTANT)
 })

--- a/tests/specs/serviceworker-opaque-point-values.spec.ts
+++ b/tests/specs/serviceworker-opaque-point-values.spec.ts
@@ -30,15 +30,18 @@ const POINT_TIMESTAMP = POINT_DATE_MS / 1000
 
 const GENERATOR_ID = 'datestring-server-test'
 
-// PDK uploads only when asked, and rejects until its database is open and its
-// configuration has arrived. Retrying absorbs that startup window without the
-// test inspecting the module to find out when it has passed.
+// Nothing in PDK flushes the queue on its own, so the upload has to be asked
+// for. rex-core's refreshConfiguration notifies every registered module, and
+// PDK's handler is what calls uploadQueuedDataPoints, so the test can trigger
+// the upload without reaching into PDK. The response arrives before the upload
+// finishes, and the module rejects until its database is open, so the ask is
+// repeated until the point shows up rather than timed against internals.
 const fetchPointsFromServer = async (serviceWorker, request) => {
   const deadline = Date.now() + 20000
 
   for (;;) {
     await serviceWorker.evaluate(() => {
-      return self.rexPDKPlugin.uploadQueuedDataPoints(() => {}).then(() => undefined, () => undefined)
+      self.rexCorePlugin.handleMessage({ messageType: 'refreshConfiguration' }, null, () => {})
     })
 
     const response = await request.get(`/data/points.json?timestamp=${POINT_TIMESTAMP}`)

--- a/tests/specs/serviceworker-opaque-point-values.spec.ts
+++ b/tests/specs/serviceworker-opaque-point-values.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from './fixtures';
+
+// These tests pin the defect fixed in 6341080: persisting a point with
+// `objectStore.add(point)` handed the raw object to the structured clone
+// algorithm, which copies only own enumerable properties. A value that keeps
+// its state in private slots and exposes it through `toJSON` on the prototype
+// therefore cloned to `{}` — without raising DataCloneError. The point was
+// saved and uploaded looking well-formed, with the value silently gone.
+//
+// This is how every rex-types `DateString` lost its timestamp: it wraps a
+// `Temporal.Instant` from @js-temporal/polyfill, which has no own enumerable
+// properties. rex-spider-chatgpt writes three of them per conversation
+// (`started`, `ended`, and `when` on every turn), so conversation timing was
+// blank in the collected data while the conversations themselves arrived fine.
+//
+// `opaqueStamp` below reproduces that shape without pulling in the polyfill:
+// no own enumerable properties, value reachable only via prototype `toJSON`.
+// Guard when editing: if it ever gains an own enumerable property, structured
+// clone starts preserving it and these tests pass against the defect.
+
+const ISO_STAMP = '2026-04-30T17:30:08.089696768Z'
+
+const enqueueOpaquePoint = (serviceWorker, generatorId: string) => {
+  return serviceWorker.evaluate(async ({ generatorId, iso }) => {
+    const pdk = self.rexPDKPlugin
+
+    const waitFor = (condition: () => boolean, timeoutMs: number, label: string) => {
+      return new Promise<void>((resolve, reject) => {
+        const started = Date.now()
+
+        const poll = () => {
+          if (condition()) {
+            resolve()
+          } else if (Date.now() - started > timeoutMs) {
+            reject(new Error(`Timed out waiting for: ${label}`))
+          } else {
+            self.setTimeout(poll, 25)
+          }
+        }
+
+        poll()
+      })
+    }
+
+    const countPoints = () => {
+      return new Promise<number>((resolve) => {
+        const request = pdk.database.transaction(['dataPoints'], 'readonly').objectStore('dataPoints').count()
+
+        request.onsuccess = () => resolve(request.result)
+      })
+    }
+
+    await waitFor(() => pdk.database !== null && pdk.uploadUrl !== '', 10000, 'database open and configuration loaded')
+
+    // Stands in for Temporal.Instant: structured clone sees nothing to copy,
+    // JSON serialization reaches the value through the prototype.
+    const opaqueStamp = Object.create({ toJSON: () => iso })
+
+    if (Object.keys(opaqueStamp).length !== 0) {
+      throw new Error('Test setup invalid: opaqueStamp must have no own enumerable properties.')
+    }
+
+    // Mirrors the post-content-processing shape of a DateString: the walker in
+    // rex-content-processing rebuilds objects as plain ones, so the DateString
+    // prototype is already gone and only the inner stamp carries toJSON.
+    pdk.enqueueDataPoint(generatorId, {
+      ended: {
+        value: opaqueStamp,
+        originalValue: ''
+      }
+    })
+
+    const started = Date.now()
+
+    while ((await countPoints()) < 1) {
+      if (Date.now() - started > 5000) {
+        throw new Error('Timed out waiting for the point to persist to IndexedDB.')
+      }
+
+      await new Promise((resolve) => self.setTimeout(resolve, 25))
+    }
+  }, { generatorId, iso: ISO_STAMP })
+}
+
+test('a point value reachable only through toJSON survives the persist to IndexedDB', async ({serviceWorker}) => {
+  await enqueueOpaquePoint(serviceWorker, 'opaque-persist-test')
+
+  const persisted = await serviceWorker.evaluate(async (generatorId) => {
+    return new Promise((resolve) => {
+      const request = self.rexPDKPlugin.database.transaction(['dataPoints'], 'readonly').objectStore('dataPoints').getAll()
+
+      request.onsuccess = () => {
+        const record = request.result.find((candidate) => candidate.generatorId === generatorId)
+
+        resolve(record === undefined ? null : record.dataPoint)
+      }
+    })
+  }, 'opaque-persist-test')
+
+  expect(persisted).not.toBeNull()
+
+  // The defect wrote `{}` here rather than failing, so asserting on the value
+  // is the only thing that catches it.
+  expect(persisted['ended']['value']).toEqual(ISO_STAMP)
+  expect(persisted['ended']['originalValue']).toEqual('')
+})
+
+test('a point value reachable only through toJSON survives the upload payload', async ({serviceWorker}) => {
+  await enqueueOpaquePoint(serviceWorker, 'opaque-upload-test')
+
+  const uploaded = await serviceWorker.evaluate(async (generatorId) => {
+    const responses = await self.rexPDKPlugin.uploadQueuedDataPoints(() => {})
+
+    for (const response of responses) {
+      for (const point of response.payload) {
+        if (point['passive-data-metadata']['generator-id'] === generatorId) {
+          return point
+        }
+      }
+    }
+
+    return null
+  }, 'opaque-upload-test')
+
+  expect(uploaded).not.toBeNull()
+  expect(uploaded['ended']['value']).toEqual(ISO_STAMP)
+})

--- a/tests/specs/serviceworker-opaque-point-values.spec.ts
+++ b/tests/specs/serviceworker-opaque-point-values.spec.ts
@@ -2,31 +2,32 @@ import { test, expect } from './fixtures';
 
 // These tests pin the defect fixed in 6341080: persisting a point with
 // `objectStore.add(point)` handed the raw object to the structured clone
-// algorithm, which copies only own enumerable properties. A value that keeps
-// its state in private slots and exposes it through `toJSON` on the prototype
-// therefore cloned to `{}` — without raising DataCloneError. The point was
-// saved and uploaded looking well-formed, with the value silently gone.
+// algorithm, which copies only own enumerable properties. A rex-types
+// `DateString` holds its instant in a `Temporal.Instant` from
+// @js-temporal/polyfill, whose state lives in private slots, so the clone
+// wrote `{ value: {}, originalValue: '' }` and the timestamp was gone.
 //
-// This is how every rex-types `DateString` lost its timestamp: it wraps a
-// `Temporal.Instant` from @js-temporal/polyfill, which has no own enumerable
-// properties. rex-spider-chatgpt writes three of them per conversation
-// (`started`, `ended`, and `when` on every turn), so conversation timing was
-// blank in the collected data while the conversations themselves arrived fine.
+// Nothing raised DataCloneError. The point persisted, uploaded, and arrived at
+// the server looking well formed, which is why this ran unnoticed. Asserting on
+// the value is the only thing that catches it.
 //
-// `opaqueStamp` below reproduces that shape without pulling in the polyfill:
-// no own enumerable properties, value reachable only via prototype `toJSON`.
-// Guard when editing: if it ever gains an own enumerable property, structured
-// clone starts preserving it and these tests pass against the defect.
+// rex-spider-chatgpt writes three DateStrings per conversation (`started`,
+// `ended`, and `when` on every turn), and all of them arrived empty.
+//
+// The tests use the real DateString rather than a local stand-in. A stand-in
+// can only encode what we already believe the type does; if DateString or the
+// polyfill changes shape, an imitation keeps passing while collection breaks.
 
-const ISO_STAMP = '2026-04-30T17:30:08.089696768Z'
+// Epoch seconds, the form ChatGPT emits and DateString accepts.
+const CONVERSATION_EPOCH_SECONDS = 1777570208.089697
 
-// Pins `passive-data-metadata.timestamp` so the server-side test can retrieve
-// exactly this point. stampPointMetadata derives that field as `date / 1000`.
+// stampPointMetadata derives `passive-data-metadata.timestamp` as `date / 1000`,
+// so pinning `date` is what lets the server-side test retrieve this point.
 const POINT_DATE_MS = 1777570208089
 const POINT_TIMESTAMP = POINT_DATE_MS / 1000
 
-const enqueueOpaquePoint = (serviceWorker, generatorId: string) => {
-  return serviceWorker.evaluate(async ({ generatorId, iso, dateMs }) => {
+const dispatchConversationPoint = (serviceWorker, generatorId: string) => {
+  return serviceWorker.evaluate(async ({ generatorId, epochSeconds, dateMs }) => {
     const pdk = self.rexPDKPlugin
 
     const waitFor = (condition: () => boolean, timeoutMs: number, label: string) => {
@@ -57,13 +58,12 @@ const enqueueOpaquePoint = (serviceWorker, generatorId: string) => {
 
     await waitFor(() => pdk.database !== null && pdk.uploadUrl !== '', 10000, 'database open and configuration loaded')
 
-    // Stands in for Temporal.Instant: structured clone sees nothing to copy,
-    // JSON serialization reaches the value through the prototype. Nested under
-    // `value` to match a DateString, which holds its instant that way.
-    const opaqueStamp = Object.create({ toJSON: () => iso })
+    const stamp = new self.rexDateString(epochSeconds)
 
-    if (Object.keys(opaqueStamp).length !== 0) {
-      throw new Error('Test setup invalid: opaqueStamp must have no own enumerable properties.')
+    // Fails loudly if DateString stops being the thing this test assumes: a
+    // value the structured clone algorithm cannot carry.
+    if (Object.keys(stamp.value).length !== 0) {
+      throw new Error('Test setup invalid: DateString.value now has own enumerable properties, so structured clone would preserve it and this test could no longer fail.')
     }
 
     const before = await countPoints()
@@ -71,14 +71,12 @@ const enqueueOpaquePoint = (serviceWorker, generatorId: string) => {
     // Goes in the way a real producer does: rex-core's dispatchEvent fans the
     // event out to every registered module, so this covers logEvent and the
     // content-processing pass rather than starting at enqueueDataPoint. The
-    // spider reaches PDK by exactly this route.
+    // spider reaches PDK by exactly this route, with these field names.
     self.rexDispatchEvent({
       name: generatorId,
       date: dateMs,
-      ended: {
-        value: opaqueStamp,
-        originalValue: ''
-      }
+      started: stamp,
+      ended: stamp
     })
 
     const started = Date.now()
@@ -90,11 +88,19 @@ const enqueueOpaquePoint = (serviceWorker, generatorId: string) => {
 
       await new Promise((resolve) => self.setTimeout(resolve, 25))
     }
-  }, { generatorId, iso: ISO_STAMP, dateMs: POINT_DATE_MS })
+
+    return stamp.toJSON()
+  }, { generatorId, epochSeconds: CONVERSATION_EPOCH_SECONDS, dateMs: POINT_DATE_MS })
 }
 
-test('a point value reachable only through toJSON survives the persist to IndexedDB', async ({serviceWorker}) => {
-  await enqueueOpaquePoint(serviceWorker, 'opaque-persist-test')
+// No content processor is registered in this harness, so the DateString reaches
+// serialization with its prototype intact and its own toJSON flattens it to an
+// ISO string. A consumer that registers one (Keystone registers openredaction)
+// gets `{ value: <iso>, originalValue: '' }` instead, because the processing
+// walker rebuilds objects as plain ones and drops the prototype. Either way the
+// instant survives, and either way the defect replaced it with `{}`.
+test('a DateString on a dispatched point survives the persist to IndexedDB', async ({serviceWorker}) => {
+  const expectedIso = await dispatchConversationPoint(serviceWorker, 'datestring-persist-test')
 
   const persisted = await serviceWorker.evaluate(async (generatorId) => {
     return new Promise((resolve) => {
@@ -106,18 +112,15 @@ test('a point value reachable only through toJSON survives the persist to Indexe
         resolve(record === undefined ? null : record.dataPoint)
       }
     })
-  }, 'opaque-persist-test')
+  }, 'datestring-persist-test')
 
   expect(persisted).not.toBeNull()
-
-  // The defect wrote `{}` here rather than failing, so asserting on the value
-  // is the only thing that catches it.
-  expect(persisted['ended']['value']).toEqual(ISO_STAMP)
-  expect(persisted['ended']['originalValue']).toEqual('')
+  expect(persisted['started']).toEqual(expectedIso)
+  expect(persisted['ended']).toEqual(expectedIso)
 })
 
-test('the value the server receives is the timestamp, not an empty object', async ({serviceWorker, request}) => {
-  await enqueueOpaquePoint(serviceWorker, 'opaque-server-test')
+test('the DateString the server receives is the instant, not an empty object', async ({serviceWorker, request}) => {
+  const expectedIso = await dispatchConversationPoint(serviceWorker, 'datestring-server-test')
 
   await serviceWorker.evaluate(() => self.rexPDKPlugin.uploadQueuedDataPoints(() => {}))
 
@@ -129,9 +132,9 @@ test('the value the server receives is the timestamp, not an empty object', asyn
 
   const body = await response.json()
 
-  const received = body.points.find((point) => point['passive-data-metadata']['generator-id'] === 'opaque-server-test')
+  const received = body.points.find((point) => point['passive-data-metadata']['generator-id'] === 'datestring-server-test')
 
   expect(received).toBeDefined()
-  expect(received['ended']['value']).toEqual(ISO_STAMP)
-  expect(received['ended']['originalValue']).toEqual('')
+  expect(received['started']).toEqual(expectedIso)
+  expect(received['ended']).toEqual(expectedIso)
 })

--- a/tests/src/service-worker.ts
+++ b/tests/src/service-worker.ts
@@ -1,5 +1,6 @@
 import { REXConfiguration } from '@bric/rex-core/common'
 import corePlugin, { dispatchEvent } from '@bric/rex-core/service-worker'
+import { DateString } from '@bric/rex-types/types'
 import pdkPlugin, { PassiveDataKitPointAnnotator, REXPDKDataPoint } from '@bric/rex-passive-data-kit/service-worker'
 
 console.log(`Imported ${corePlugin} into service worker context...`)
@@ -12,6 +13,12 @@ self['rexPDKPlugin'] = pdkPlugin
 // a native one, so a test calling the bare name would dispatch a DOM event and
 // silently exercise nothing.
 self['rexDispatchEvent'] = dispatchEvent
+
+// The real DateString, so the persistence tests exercise the actual type that
+// lost its value rather than a local imitation of it. A stand-in can only
+// encode what we already believe about DateString; if the type changes, the
+// stand-in keeps passing while collection breaks.
+self['rexDateString'] = DateString
 
 class TestDataPointAnnotator extends PassiveDataKitPointAnnotator {
   annotate(dataPoint: REXPDKDataPoint): Promise<void> {

--- a/tests/src/service-worker.ts
+++ b/tests/src/service-worker.ts
@@ -9,16 +9,17 @@ console.log(`Imported ${pdkPlugin} into service worker context...`)
 self['rexCorePlugin'] = corePlugin
 self['rexPDKPlugin'] = pdkPlugin
 
-// Deliberately not named `dispatchEvent`: the service worker scope already has
-// a native one, so a test calling the bare name would dispatch a DOM event and
-// silently exercise nothing.
-self['rexDispatchEvent'] = dispatchEvent
+// rex-core exports dispatchEvent at module scope rather than on the plugin, so
+// the harness has to put it on `self` for a spec to reach it. Assigning the
+// bare name shadows EventTarget's dispatchEvent, which the worker scope also
+// has and which nothing here uses.
+self['dispatchEvent'] = dispatchEvent
 
 // The real DateString, so the persistence tests exercise the actual type that
 // lost its value rather than a local imitation of it. A stand-in can only
 // encode what we already believe about DateString; if the type changes, the
 // stand-in keeps passing while collection breaks.
-self['rexDateString'] = DateString
+self['DateString'] = DateString
 
 class TestDataPointAnnotator extends PassiveDataKitPointAnnotator {
   annotate(dataPoint: REXPDKDataPoint): Promise<void> {

--- a/tests/src/service-worker.ts
+++ b/tests/src/service-worker.ts
@@ -1,5 +1,5 @@
 import { REXConfiguration } from '@bric/rex-core/common'
-import corePlugin from '@bric/rex-core/service-worker'
+import corePlugin, { dispatchEvent } from '@bric/rex-core/service-worker'
 import pdkPlugin, { PassiveDataKitPointAnnotator, REXPDKDataPoint } from '@bric/rex-passive-data-kit/service-worker'
 
 console.log(`Imported ${corePlugin} into service worker context...`)
@@ -7,6 +7,11 @@ console.log(`Imported ${pdkPlugin} into service worker context...`)
 
 self['rexCorePlugin'] = corePlugin
 self['rexPDKPlugin'] = pdkPlugin
+
+// Deliberately not named `dispatchEvent`: the service worker scope already has
+// a native one, so a test calling the bare name would dispatch a DOM event and
+// silently exercise nothing.
+self['rexDispatchEvent'] = dispatchEvent
 
 class TestDataPointAnnotator extends PassiveDataKitPointAnnotator {
   annotate(dataPoint: REXPDKDataPoint): Promise<void> {


### PR DESCRIPTION
# Add regression coverage for point values that structured clone silently drops

## Why

The defect fixed in [`6341080`](https://github.com/bric-digital/rex-passive-data-kit/commit/6341080a549f6d227c5572e4d4de0a40b5f46064) went unnoticed because nothing in this repo could catch it, and the fix landed without a test pinning it. The same class of loss can regress on the next refactor of the persist path with a fully green suite.

Two gaps let it through:

1. **No test enqueued a value that structured clone flattens.** Existing specs persist plain objects such as `{ test: 'a' }`, which clone cleanly, so `objectStore.add(point)` always looked healthy. The defect only appears for values holding state in private slots, which is what a `rex-types` `DateString` does: it wraps a `Temporal.Instant` from `@js-temporal/polyfill`.
2. **The mock server retained nothing.** It validated and echoed each payload, so a test could assert what the client believed it sent but never what the server actually received. Those are not the same claim, and this defect lives precisely in the gap between them.

What made it costly is that the failure is silent. `structuredClone` does not raise `DataCloneError` on these values. It copies zero enumerable properties and writes `{}`, so points persisted and uploaded looking well formed, with the value gone. No error, no rejected upload, nothing in a log for a reviewer to notice.

**Who this affects:** every consumer sending points that contain anything other than plain data. `rex-spider-chatgpt` writes three `DateString`s per conversation (`started`, `ended`, and `when` on every turn), and all of them arrived empty.

**What breaks without this change:** nothing today, since the fix is already on `main`. The risk is forward-looking. Without coverage, the next change to the persist path can reintroduce silent value loss and the suite will still pass, which is exactly how this reached participants the first time.

## What changed

Tests and test infrastructure only. **No change to `src/`.** This PR adds no behavior and is safe to read as pure coverage.

| File | Change |
| --- | --- |
| `tests/specs/serviceworker-opaque-point-values.spec.ts` | New. One end-to-end regression test. |
| `tests/scripts/data-point-store.js` | New. Retains accepted points so a test can query what the server received. |
| `tests/scripts/run-server.js` | Records accepted points on all three ingest routes; adds two endpoints. |
| `tests/src/service-worker.ts` | Exposes rex-core's `dispatchEvent` and the real `DateString` to the test context. |
| `package.json`, `package-lock.json` | Adds `@bric/rex-types` as a devDependency, for the real `DateString`. |

## The test

One test, asserting only on what the server returned. It dispatches a single point carrying two real `DateString`s through rex-core, asks rex-core to refresh configuration (which is what prompts PDK to upload), and queries the mock server for the point at a pinned timestamp.

The spec names no PDK object. Both ends of it are rex-core:

```ts
self.dispatchEvent({ name: generatorId, date: dateMs, started: stamp, ended: stamp })
...
self.rexCorePlugin.handleMessage({ messageType: 'refreshConfiguration' }, null, () => {})
```

The upload has to be asked for. Nothing in PDK flushes the queue on a timer or an alarm — `refreshConfiguration` is the only internal caller of `uploadQueuedDataPoints` — so a dispatch followed by a wait never reaches the server on its own. rex-core's `refreshConfiguration` handler notifies every registered module, and PDK's handler is what performs the upload, so the test can trigger it without reaching into the module.

The test cannot use the simpler `transmitSynchronousEvent` message the other specs use, because that handler goes straight to `transmitDataPoint` and never reaches `objectStore.add`. A test built on it would pass with or without the fix.

### It uses the real DateString

The test constructs an actual `DateString` rather than a local imitation. An imitation can only encode what we already believe the type does, so if `DateString` or the polyfill changes shape, the imitation keeps passing while collection breaks. That is the failure mode this PR exists to prevent.

`@bric/rex-types` is therefore a devDependency, and the harness exposes the class under its own name. Both it and `dispatchEvent` have to sit on the worker global: a class cannot cross the `serviceWorker.evaluate` boundary, so the instance has to be constructed inside the worker, and rex-core exports `dispatchEvent` at module scope rather than on the plugin. The bare-name assignment shadows `EventTarget`'s `dispatchEvent`, which the worker scope does have and which nothing here uses.

### Retrieving points by timestamp

The mock server now keeps what it accepts and can be asked about it:

```
GET    /data/points.json?timestamp=<epoch-seconds>[&tolerance=<seconds>]
DELETE /data/points.json
```

`GET` returns `{ timestamp, tolerance, count, points }`, matching on `passive-data-metadata.timestamp`. The test pins that value by setting `date` on the point it dispatches, since `stampPointMetadata` derives the field as `date / 1000`. `tolerance` defaults to `0` and exists because those timestamps are floats carrying sub-millisecond precision.

The store holds points, never bundles. A bundle is a transport envelope with no timestamp of its own, so storing one would leave nothing to query by. The bundle routes unwrap and record each point they carry, through `recordPoints`, while the single-point route uses `recordPoint`.

Recording happens only after a route's validation passes. The store stands for what the server persisted, and a payload rejected with a 400 was never written, so retaining it would report points the server does not have.

## What using the real type revealed

Two things, both worth recording.

**Serialization shape depends on the consumer.** In this harness, with no content processor registered, a `DateString` reaches serialization with its prototype intact, so its own `toJSON` flattens it:

```json
"started": "2026-04-30T17:30:08.089696768Z"
```

A consumer that registers a processor gets the nested form instead, because the content-processing walker rebuilds objects as plain ones and drops the prototype:

```json
"started": { "value": "2026-04-30T17:30:08.089696768Z", "originalValue": "" }
```

Both shapes are real. Keystone registers openredaction, so it sees the nested form.

**Points dispatched before configuration loads are lost silently.** `fetchConfiguration()` resolves `undefined` for roughly the first 500ms after the worker starts, and a point dispatched in that window never arrives: `enqueueDataPoint` hands the undefined configuration to `normalizeConfiguration`, that throws inside the `.then()`, and the point goes with the rejection. No error surfaces. This is why the test waits for a configuration carrying `passive_data_kit` before dispatching. Filed as #51 rather than changed here, since this PR touches no `src/`.

## Verification

The test was checked against both states of the fix, since a regression test that cannot fail is not coverage:

| Code state | Result |
| --- | --- |
| `main` as it stands | pass |
| Fix reverted to `objectStore.add(point)`, test bundle rebuilt | fail |
| Fix restored | `src/` clean per `git diff` |

The failure it produces:

```
Expected: "2026-04-30T17:30:08.089696768Z"
Received: {"originalValue": "number:1777570208.089697", "value": {}}
```

That failure is server-side, which is the meaningful part: it shows the empty object genuinely crossed the wire and was stored, rather than the client misreporting on its way out.

Full suite after restoring: **9 passed**, `npm run lint` exit 0. Also run with `--repeat-each=3` to check for flakiness in the upload retry loop.

## Responses to review

Round two asked for one thing consistently: stop poking PDK internals, keep only the end-to-end test. All of it is applied.

- **The IndexedDB test is gone.** One test remains, asserting only on what the server returned.
- **No PDK object appears in the spec.** The point goes in through rex-core's `dispatchEvent` and the upload is triggered through rex-core's `refreshConfiguration` message.
- **No point counting.** One point, one pinned timestamp, `expect(body.count).toEqual(1)`.
- **No aliases.** `self.DateString` and `self.dispatchEvent`, under their own names.
- **No intermediate instance in the assertions.** The expectation is a literal ISO string. The trade-off, flagged in the thread: nothing now asserts that `DateString` is still a value structured clone cannot carry.
- **Readiness without internals.** The wait polls rex-core's `fetchConfiguration()` rather than reading `pdk.database` and `pdk.uploadUrl`. That change is what surfaced the silent-drop finding above.
